### PR TITLE
  fix bug compileTestData in linux:

### DIFF
--- a/TESTS/scripts/compileTestData.py
+++ b/TESTS/scripts/compileTestData.py
@@ -5,12 +5,6 @@ import shutil
 DATA_DIR = "PRE-GEN"
 OUTPUT_DIR = "testData"
 
-FULL_OUTPUT_DIR = (Path.cwd() / OUTPUT_DIR).resolve()
-FULL_PREGEN_DIR = (Path.cwd() / DATA_DIR).resolve()
-TEST_DATA_DIR = FULL_OUTPUT_DIR
-
-print("FULL_OUTPUT_DIR", FULL_OUTPUT_DIR)
-print("FULL_PREGEN_DIR", FULL_PREGEN_DIR)
 
 
 def mkdir(path, dirname):
@@ -23,7 +17,7 @@ def mkdir(path, dirname):
     outPath = outPath / dirname
 
     if not outPath.exists():
-        os.makedirs(outPath)
+        os.makedirs(str(outPath))
     elif outPath.exists() and not outPath.is_dir():
         print("invalid path")
         return
@@ -31,17 +25,24 @@ def mkdir(path, dirname):
     return outPath
 
 
+mkdir(Path.cwd(), OUTPUT_DIR)
+FULL_OUTPUT_DIR = (Path.cwd() / OUTPUT_DIR).resolve()
+FULL_PREGEN_DIR = (Path.cwd() / DATA_DIR).resolve()
+TEST_DATA_DIR = FULL_OUTPUT_DIR
+
+print("FULL_OUTPUT_DIR", FULL_OUTPUT_DIR)
+print("FULL_PREGEN_DIR", FULL_PREGEN_DIR)
 
 
 #remove the output directry and start clean:
 if Path(FULL_OUTPUT_DIR).exists():
-    shutil.rmtree(FULL_OUTPUT_DIR)
+    shutil.rmtree(str(FULL_OUTPUT_DIR))
 
 #copy the pre-generated date to output:
-shutil.copytree(FULL_PREGEN_DIR, FULL_OUTPUT_DIR)
+shutil.copytree(str(FULL_PREGEN_DIR), str(FULL_OUTPUT_DIR))
 
 #run all scripts to generate the data
 run_items = Path.cwd().glob("GEN_SCR/*/*.py")
 
 for item in run_items:
-    exec(open(item).read())
+    exec(open(str(item), "r").read())


### PR DESCRIPTION
    1. before path object resolve called, the directory shold be
    existed.
    2. in os module function, the parameter should be str type
    rather than PosixPath object.
    3. it test on ubuntu 16.04 and Mac OS (python3.6)