### PR TITLE
  optimize gemm operation

### DIFF
--- a/MatrixOps.hpp
+++ b/MatrixOps.hpp
@@ -143,7 +143,7 @@ void multMat(Mat A, Mat B, Mat C) {
     }
 
 template <class T1, class T2, class T3>
-void ReferenceGemm(bool transpose_a, bool transpose_b, bool transpose_c,
+void ReferenceGemmuImpl(bool transpose_a, bool transpose_b, bool transpose_c,
                    size_t m, size_t n, size_t k, const T1* a, int32 offset_a,
                    size_t lda, const T2* b, int32 offset_b, size_t ldb, T3* c,
                    int32 shift_c, int32 offset_c, int32 mult_c, size_t ldc) {

--- a/MatrixOps.hpp
+++ b/MatrixOps.hpp
@@ -141,6 +141,64 @@ void multMat(Mat A, Mat B, Mat C) {
         }
       }
     }
+
+template <class T1, class T2, class T3>
+void ReferenceGemm(bool transpose_a, bool transpose_b, bool transpose_c,
+                   size_t m, size_t n, size_t k, const T1* a, int32 offset_a,
+                   size_t lda, const T2* b, int32 offset_b, size_t ldb, T3* c,
+                   int32 shift_c, int32 offset_c, int32 mult_c, size_t ldc) {
+
+    int a_i_stride = lda;
+    int a_l_stride = 1;
+    if (transpose_a) {
+     a_i_stride = 1;
+     a_l_stride = lda;
+    }
+
+    int b_j_stride = 1;
+    int b_l_stride = ldb;
+    if (transpose_b) {
+      b_j_stride = ldb;
+      b_l_stride = 1;
+    }
+
+    int c_i_stride = ldc;
+    int c_j_stride = 1;
+    if (transpose_c) {
+      c_i_stride = 1;
+      c_j_stride = ldc;
+    }
+
+    //   const int32 highest = static_cast<int32>(Eigen::NumTraits<T3>::highest());
+    //   const int32 lowest = static_cast<int32>(Eigen::NumTraits<T3>::lowest());
+    const int32 highest = static_cast<int32>(std::numeric_limits<T3>::max());
+    const int32 lowest = static_cast<int32>(std::numeric_limits<T3>::min());
+    const int32 rounding = (shift_c < 1) ? 0 : (1 << (shift_c - 1));
+
+    int i, j, l;
+    for (j = 0; j < n; j++) {
+      for (i = 0; i < m; i++) {
+        int32 total = 0;
+        for (l = 0; l < k; l++) {
+          const size_t a_index = ((i * a_i_stride) + (l * a_l_stride));
+          const int32 a_value = static_cast<int32>(a[a_index]) - offset_a;
+          const size_t b_index = ((j * b_j_stride) + (l * b_l_stride));
+          const int32 b_value = static_cast<int32>(b[b_index]) - offset_b;
+          total += (a_value * b_value);
+        }
+        const size_t c_index = ((i * c_i_stride) + (j * c_j_stride));
+        int32_t output = ((((total + offset_c) * mult_c) + rounding) >> shift_c);
+        if (output > highest) {
+          output = highest;
+        }
+
+        if (output < lowest) {
+          output = lowest;
+        }
+        c[c_index] = static_cast<T3>(output);
+      }
+   }
+}
     
 
 #endif


### PR DESCRIPTION
  1. Initialize variable x_i_stride and x_l_stride before being used, it would avoid
   avoid unintended variable used before initialized error and it would
  avoid unnecessary branch selection.