### PR TITLE
Quantize v2

### DIFF
--- a/ArrayOps.hpp
+++ b/ArrayOps.hpp
@@ -1,48 +1,10 @@
 #ifndef UTENSOR_ARRAY_OPS
 #define UTENSOR_ARRAY_OPS
 
-#include <limits>
-#include <algorithm>
 #include <cstring>
 #include <math.h>
 #include "uTensor_util.hpp"
-
-//quantization_utils.h:181
-template <typename T>
-struct FloatToQuantizedStruct {
-  static constexpr int number_of_bits = sizeof(T) * 8;
-  static constexpr int64 number_of_steps = static_cast<int64>(1)
-                                           << number_of_bits;
-  static constexpr double range_adjust =
-      (number_of_steps / (number_of_steps - 1.0));
-
-  // Casting QInt32's lowest or highest to a float gives a float that can't be
-  // cast back to int32 or QInt32.  Instead, use bounds that can be converted
-  // back to int32 without going outside the range of an int32.
-  static float lower_bound_float() {
-    return std::max(
-        static_cast<float>(std::numeric_limits<T>::lowest()), -2.147483648e+09f);
-  }
-  static float upper_bound_float() {
-    return std::min(
-        static_cast<float>(std::numeric_limits<T>::max()), +2.147483520e+09f);
-  }
-
-  static float lowest_quantized() {
-    return static_cast<float>(std::numeric_limits<T>::lowest());
-  }
-
-  FloatToQuantizedStruct(float range_min, float range_max)
-      : range_min(range_min),
-        range_scale(range_max == range_min
-                        ? 0.0
-                        : (number_of_steps - 1.0) / (range_max - range_min)),
-        range_min_scaled(round(range_min * range_scale)) {}
-
-  const float range_min;
-  const float range_scale;
-  const float range_min_scaled;
-};
+#include "quantization_utils.hpp"
 
 //T = inferred
 //mode = MIN_FIRST
@@ -85,28 +47,6 @@ void QuantizeV2(Tensor<float> input, Tensor<float> _min_range, Tensor<float> _ma
     *output_max_ptr = max_range;
     
 }
-
-template <typename T>
-struct QuantizedToFloatStruct {
-  static constexpr int number_of_bits = sizeof(T) * 8;
-  static constexpr int64 number_of_steps = static_cast<int64>(1)
-                                           << number_of_bits;
-
-  static float lowest_quantized() {
-    return static_cast<float>(std::numeric_limits<T>::lowest());
-  }
-
-  QuantizedToFloatStruct(float range_min, float range_max)
-      : range_min(range_min),
-        range_scale((range_max - range_min) / (number_of_steps - 1.0)),
-        range_min_rounded(range_max == range_min
-                              ? range_min
-                              : round(range_min / range_scale) * range_scale) {}
-
-  const float range_min;
-  const float range_scale;
-  const float range_min_rounded;
-};
 
 //mode = MIN_FIRST
 //name = unspecified

--- a/ArrayTests.hpp
+++ b/ArrayTests.hpp
@@ -74,6 +74,8 @@ public:
         //modify the checks below:
         Tensor<float> out(out_ref.getShape());
 
+        reshape(ref_a, ref_dim, out);
+
         double result = meanPercentErr(out_ref, out);
         //passed(result < 0.0001);
         passed(result == 0);

--- a/quantization_utils.hpp
+++ b/quantization_utils.hpp
@@ -1,0 +1,67 @@
+#ifndef UTENSOR_QUANT_UTILS
+#define UTENSOR_QUANT_UTILS
+
+#include <limits>
+#include <math.h>
+
+//reference: quantization_utils.h:181
+template <typename T>
+struct FloatToQuantizedStruct {
+  static constexpr int number_of_bits = sizeof(T) * 8;
+  static constexpr int64 number_of_steps = static_cast<int64>(1)
+                                           << number_of_bits;
+  static constexpr double range_adjust =
+      (number_of_steps / (number_of_steps - 1.0));
+
+  // Casting QInt32's lowest or highest to a float gives a float that can't be
+  // cast back to int32 or QInt32.  Instead, use bounds that can be converted
+  // back to int32 without going outside the range of an int32.
+  static float lower_bound_float() {
+    return std::max(
+        static_cast<float>(std::numeric_limits<T>::lowest()), -2.147483648e+09f);
+  }
+  static float upper_bound_float() {
+    return std::min(
+        static_cast<float>(std::numeric_limits<T>::max()), +2.147483520e+09f);
+  }
+
+  static float lowest_quantized() {
+    return static_cast<float>(std::numeric_limits<T>::lowest());
+  }
+
+  FloatToQuantizedStruct(float range_min, float range_max)
+      : range_min(range_min),
+        range_scale(range_max == range_min
+                        ? 0.0
+                        : (number_of_steps - 1.0) / (range_max - range_min)),
+        range_min_scaled(round(range_min * range_scale)) {}
+
+  const float range_min;
+  const float range_scale;
+  const float range_min_scaled;
+};
+
+
+template <typename T>
+struct QuantizedToFloatStruct {
+  static constexpr int number_of_bits = sizeof(T) * 8;
+  static constexpr int64 number_of_steps = static_cast<int64>(1)
+                                           << number_of_bits;
+
+  static float lowest_quantized() {
+    return static_cast<float>(std::numeric_limits<T>::lowest());
+  }
+
+  QuantizedToFloatStruct(float range_min, float range_max)
+      : range_min(range_min),
+        range_scale((range_max - range_min) / (number_of_steps - 1.0)),
+        range_min_rounded(range_max == range_min
+                              ? range_min
+                              : round(range_min / range_scale) * range_scale) {}
+
+  const float range_min;
+  const float range_scale;
+  const float range_min_rounded;
+};
+
+#endif  //UTENSOR_QUANT_UTILS


### PR DESCRIPTION
- ArrayTests.hpp -> `dequantize` passed
- ArrayTests.hpp -> `reshape` passed
- moved `FloatToQuantizedStruct` and `QuantizedToFloatStruct` from to ArrayTests.hpp quantization_utils.hpp, a newly created file.
