### PR TITLE
  fix the bug

### DIFF
--- a/test.hpp
+++ b/test.hpp
@@ -167,7 +167,7 @@ class Test {
                              fabs((float)elemA[i]));
       } else {
         if (elemB[i] != 0) {
-          accm += std::numeric_limits<float>::quiet_NaN();
+          accm += elemB[i];
         }
       }
     }


### PR DESCRIPTION
  1. std::numeric_limits<T>::quiet_NaN() will return 0 when T is float
  2. when a[i] == 0 && b[i] !=  0, accm += 0, it sould be accm += b[i]