### PR TITLE
Correct link to mbed_app.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## Configure
 
-See [mbed_app.json](blob/master/mbed_app.json)
+See [mbed_app.json](../../blob/master/mbed_app.json)
 
 ## Build Steps
 


### PR DESCRIPTION
The current README.md has a bad link to mbed_app.json.

The link has been corrected, assuming that it's suppose to point to the master blob.