### PR TITLE
F/context cg ref

### DIFF
--- a/ArrayTests.hpp
+++ b/ArrayTests.hpp
@@ -15,22 +15,22 @@ public:
         testStart("quantize_v2");
         
         //reference inputs  /Users/neitan01/Documents/mbed/uTensor.git/TESTS/scripts/PRE-GEN/qA
-        S_TENSOR b_q_ref = ctx.add(defer(t_import.float_import ("/fs/testData/qB/in/Cast_1_0.idx", "b_q_ref")));
-        S_TENSOR b_min_q_ref = ctx.add(defer(t_import.float_import("/fs/testData/qB/in/Min_1_0.idx", "b_min_q_ref")));
-        S_TENSOR b_max_q_ref = ctx.add(defer(t_import.float_import("/fs/testData/qB/in/Max_1_0.idx", "b_max_q_ref")));
+        S_TENSOR b_q_ref = ctx.addCached(hold(t_import.float_import ("/fs/testData/qB/in/Cast_1_0.idx")), "b_q_ref");
+        S_TENSOR b_min_q_ref = ctx.addCached(hold(t_import.float_import("/fs/testData/qB/in/Min_1_0.idx")), "b_min_q_ref");
+        S_TENSOR b_max_q_ref = ctx.addCached(hold(t_import.float_import("/fs/testData/qB/in/Max_1_0.idx")), "b_max_q_ref");
 
         //reference outputs
-        S_TENSOR ref_b_q = ctx.add(defer(t_import.ubyte_import("/fs/testData/qB/out/qB_0.idx", "ref_b_q")));
-        S_TENSOR ref_b_min_q = ctx.add(defer(t_import.float_import("/fs/testData/qB/out/qB_1.idx", "ref_b_min_q")));
-        S_TENSOR ref_b_max_q = ctx.add(defer(t_import.float_import("/fs/testData/qB/out/qb_2.idx", "ref_b_max_q")));
+        S_TENSOR ref_b_q = ctx.addCached(hold(t_import.ubyte_import("/fs/testData/qB/out/qB_0.idx")), "ref_b_q");
+        S_TENSOR ref_b_min_q = ctx.addCached(hold(t_import.float_import("/fs/testData/qB/out/qB_1.idx")), "ref_b_min_q");
+        S_TENSOR ref_b_max_q = ctx.addCached(hold(t_import.float_import("/fs/testData/qB/out/qb_2.idx")), "ref_b_max_q");
 
-        S_TENSOR out_b_q = ctx.add(defer(new RamTensor<unsigned char>(b_q_ref->getShape(), "b_q")));
-        S_TENSOR out_b_min_q = ctx.add(defer(new RamTensor<float>(b_min_q_ref->getShape(), "b_min_q")));
-        S_TENSOR out_b_max_q = ctx.add(defer(new RamTensor<float>(b_max_q_ref->getShape(), "b_max_q")));
+        S_TENSOR out_b_q = ctx.addCached(hold(new RamTensor<unsigned char>(b_q_ref->getShape())), "b_q");
+        S_TENSOR out_b_min_q = ctx.addCached(hold(new RamTensor<float>(b_min_q_ref->getShape())), "b_min_q");
+        S_TENSOR out_b_max_q = ctx.addCached(hold(new RamTensor<float>(b_max_q_ref->getShape())), "b_max_q");
 
         //Implementation goes here
         timer_start();
-        ctx.push(defer(new QuantizeV2Op()), {"b_q_ref", "b_min_q_ref", "b_max_q_ref"}, {"b_q", "b_min_q", "b_max_q"});
+        ctx.push_static(hold(new QuantizeV2Op()), "QuantizeV2Op", {"b_q_ref", "b_min_q_ref", "b_max_q_ref"}, {"b_q", "b_min_q", "b_max_q"});
         ctx.eval();
         timer_stop();
 
@@ -44,18 +44,18 @@ public:
         testStart("dequantize");
 
         //reference inputs
-        S_TENSOR a = ctx.add(defer(t_import.ubyte_import("/fs/testData/deQ/in/rQ_0.idx", "a")));
-        S_TENSOR a_min = ctx.add(defer(t_import.float_import("/fs/testData/deQ/in/rQ_1.idx", "a_min")));
-        S_TENSOR a_max = ctx.add(defer(t_import.float_import("/fs/testData/deQ/in/rQ_2.idx", "a_max")));
+        S_TENSOR a = ctx.addCached(hold(t_import.ubyte_import("/fs/testData/deQ/in/rQ_0.idx")), "a");
+        S_TENSOR a_min = ctx.addCached(hold(t_import.float_import("/fs/testData/deQ/in/rQ_1.idx")), "a_min");
+        S_TENSOR a_max = ctx.addCached(hold(t_import.float_import("/fs/testData/deQ/in/rQ_2.idx")), "a_max");
 
         //reference outputs
-        S_TENSOR out_ref = ctx.add(defer(t_import.float_import("/fs/testData/deQ/out/deQ_0.idx", "out_ref")));
+        S_TENSOR out_ref = ctx.addCached(hold(t_import.float_import("/fs/testData/deQ/out/deQ_0.idx")), "out_ref");
 
         //modify the checks below:
-        S_TENSOR out = ctx.add(defer(new RamTensor<float>(out_ref->getShape(), "out")));
+        S_TENSOR out = ctx.addCached(hold(new RamTensor<float>(out_ref->getShape())), "out");
 
         timer_start();
-        ctx.push(defer(new DequantizeOp()), {"a", "a_min", "a_max"}, {"out"});
+        ctx.push_static(hold(new DequantizeOp()), "DequantizeOp", {"a", "a_min", "a_max"}, {"out"});
         ctx.eval();
         timer_stop();
 
@@ -69,18 +69,18 @@ public:
         TensorIdxImporter t_import;
 
         //reference inputs
-        S_TENSOR ref_a = ctx.add(defer(t_import.float_import("/fs/testData/ref_reshape/in/Const_0.idx", "ref_a")));
-        S_TENSOR ref_dim = ctx.add(defer(t_import.int_import("/fs/testData/ref_reshape/in/Const_1_0.idx", "ref_dim")));
+        S_TENSOR ref_a = ctx.addCached(hold(t_import.float_import("/fs/testData/ref_reshape/in/Const_0.idx")), "ref_a");
+        S_TENSOR ref_dim = ctx.addCached(hold(t_import.int_import("/fs/testData/ref_reshape/in/Const_1_0.idx")), "ref_dim");
 
         //reference outputs
-        S_TENSOR out_ref_2 = ctx.add(defer(t_import.float_import("/fs/testData/ref_reshape/out/ref_reshape_0.idx", "out_ref_2")));
+        S_TENSOR out_ref_2 = ctx.addCached(hold(t_import.float_import("/fs/testData/ref_reshape/out/ref_reshape_0.idx")), "out_ref_2");
 
         //modify the checks below:
-        S_TENSOR out_2 = ctx.add(defer(new RamTensor<float>(out_ref_2->getShape(), "out_2")));
+        S_TENSOR out_2 = ctx.addCached(hold(new RamTensor<float>(out_ref_2->getShape())), "out_2");
         
 
         timer_start();
-        ctx.push(defer(new ReshapeOp()), {"ref_a", "ref_dim"}, {"out_2"});
+        ctx.push_static(hold(new ReshapeOp()), "ReshapeOp", {"ref_a", "ref_dim"}, {"out_2"});
         ctx.eval();
         timer_stop();
 

--- a/ArrayTests.hpp
+++ b/ArrayTests.hpp
@@ -15,22 +15,22 @@ public:
         testStart("quantize_v2");
         
         //reference inputs  /Users/neitan01/Documents/mbed/uTensor.git/TESTS/scripts/PRE-GEN/qA
-        S_TENSOR b_q_ref = ctx.add(t_import.float_import ("/fs/testData/qB/in/Cast_1_0.idx", "b_q_ref"));
-        S_TENSOR b_min_q_ref = ctx.add(t_import.float_import("/fs/testData/qB/in/Min_1_0.idx", "b_min_q_ref"));
-        S_TENSOR b_max_q_ref = ctx.add(t_import.float_import("/fs/testData/qB/in/Max_1_0.idx", "b_max_q_ref"));
+        S_TENSOR b_q_ref = ctx.add(defer(t_import.float_import ("/fs/testData/qB/in/Cast_1_0.idx", "b_q_ref")));
+        S_TENSOR b_min_q_ref = ctx.add(defer(t_import.float_import("/fs/testData/qB/in/Min_1_0.idx", "b_min_q_ref")));
+        S_TENSOR b_max_q_ref = ctx.add(defer(t_import.float_import("/fs/testData/qB/in/Max_1_0.idx", "b_max_q_ref")));
 
         //reference outputs
-        S_TENSOR ref_b_q = ctx.add(t_import.ubyte_import("/fs/testData/qB/out/qB_0.idx", "ref_b_q"));
-        S_TENSOR ref_b_min_q = ctx.add(t_import.float_import("/fs/testData/qB/out/qB_1.idx", "ref_b_min_q"));
-        S_TENSOR ref_b_max_q = ctx.add(t_import.float_import("/fs/testData/qB/out/qb_2.idx", "ref_b_max_q"));
+        S_TENSOR ref_b_q = ctx.add(defer(t_import.ubyte_import("/fs/testData/qB/out/qB_0.idx", "ref_b_q")));
+        S_TENSOR ref_b_min_q = ctx.add(defer(t_import.float_import("/fs/testData/qB/out/qB_1.idx", "ref_b_min_q")));
+        S_TENSOR ref_b_max_q = ctx.add(defer(t_import.float_import("/fs/testData/qB/out/qb_2.idx", "ref_b_max_q")));
 
-        S_TENSOR out_b_q = ctx.add(new RamTensor<unsigned char>(b_q_ref->getShape(), "b_q"));
-        S_TENSOR out_b_min_q = ctx.add(new RamTensor<float>(b_min_q_ref->getShape(), "b_min_q"));
-        S_TENSOR out_b_max_q = ctx.add(new RamTensor<float>(b_max_q_ref->getShape(), "b_max_q"));
+        S_TENSOR out_b_q = ctx.add(defer(new RamTensor<unsigned char>(b_q_ref->getShape(), "b_q")));
+        S_TENSOR out_b_min_q = ctx.add(defer(new RamTensor<float>(b_min_q_ref->getShape(), "b_min_q")));
+        S_TENSOR out_b_max_q = ctx.add(defer(new RamTensor<float>(b_max_q_ref->getShape(), "b_max_q")));
 
         //Implementation goes here
         timer_start();
-        ctx.push(new QuantizeV2Op(), {"b_q_ref", "b_min_q_ref", "b_max_q_ref"}, {"b_q", "b_min_q", "b_max_q"});
+        ctx.push(defer(new QuantizeV2Op()), {"b_q_ref", "b_min_q_ref", "b_max_q_ref"}, {"b_q", "b_min_q", "b_max_q"});
         ctx.eval();
         timer_stop();
 
@@ -44,18 +44,18 @@ public:
         testStart("dequantize");
 
         //reference inputs
-        S_TENSOR a = ctx.add(t_import.ubyte_import("/fs/testData/deQ/in/rQ_0.idx", "a"));
-        S_TENSOR a_min = ctx.add(t_import.float_import("/fs/testData/deQ/in/rQ_1.idx", "a_min"));
-        S_TENSOR a_max = ctx.add(t_import.float_import("/fs/testData/deQ/in/rQ_2.idx", "a_max"));
+        S_TENSOR a = ctx.add(defer(t_import.ubyte_import("/fs/testData/deQ/in/rQ_0.idx", "a")));
+        S_TENSOR a_min = ctx.add(defer(t_import.float_import("/fs/testData/deQ/in/rQ_1.idx", "a_min")));
+        S_TENSOR a_max = ctx.add(defer(t_import.float_import("/fs/testData/deQ/in/rQ_2.idx", "a_max")));
 
         //reference outputs
-        S_TENSOR out_ref = ctx.add(t_import.float_import("/fs/testData/deQ/out/deQ_0.idx", "out_ref"));
+        S_TENSOR out_ref = ctx.add(defer(t_import.float_import("/fs/testData/deQ/out/deQ_0.idx", "out_ref")));
 
         //modify the checks below:
-        S_TENSOR out = ctx.add(new RamTensor<float>(out_ref->getShape(), "out"));
+        S_TENSOR out = ctx.add(defer(new RamTensor<float>(out_ref->getShape(), "out")));
 
         timer_start();
-        ctx.push(new DequantizeOp(), {"a", "a_min", "a_max"}, {"out"});
+        ctx.push(defer(new DequantizeOp()), {"a", "a_min", "a_max"}, {"out"});
         ctx.eval();
         timer_stop();
 
@@ -69,18 +69,18 @@ public:
         TensorIdxImporter t_import;
 
         //reference inputs
-        S_TENSOR ref_a = ctx.add(t_import.float_import("/fs/testData/ref_reshape/in/Const_0.idx", "ref_a"));
-        S_TENSOR ref_dim = ctx.add(t_import.int_import("/fs/testData/ref_reshape/in/Const_1_0.idx", "ref_dim"));
+        S_TENSOR ref_a = ctx.add(defer(t_import.float_import("/fs/testData/ref_reshape/in/Const_0.idx", "ref_a")));
+        S_TENSOR ref_dim = ctx.add(defer(t_import.int_import("/fs/testData/ref_reshape/in/Const_1_0.idx", "ref_dim")));
 
         //reference outputs
-        S_TENSOR out_ref_2 = ctx.add(t_import.float_import("/fs/testData/ref_reshape/out/ref_reshape_0.idx", "out_ref_2"));
+        S_TENSOR out_ref_2 = ctx.add(defer(t_import.float_import("/fs/testData/ref_reshape/out/ref_reshape_0.idx", "out_ref_2")));
 
         //modify the checks below:
-        S_TENSOR out_2 = ctx.add(new RamTensor<float>(out_ref_2->getShape(), "out_2"));
+        S_TENSOR out_2 = ctx.add(defer(new RamTensor<float>(out_ref_2->getShape(), "out_2")));
         
 
         timer_start();
-        ctx.push(new ReshapeOp(), {"ref_a", "ref_dim"}, {"out_2"});
+        ctx.push(defer(new ReshapeOp()), {"ref_a", "ref_dim"}, {"out_2"});
         ctx.eval();
         timer_stop();
 

--- a/MathTests.hpp
+++ b/MathTests.hpp
@@ -17,24 +17,24 @@ class MathOpsTest : public Test {
 
     //Note: raw pointers should be owned ONLY by the context. no copy of the raw pointer should exist elsewhere
     // reference inputs
-    ctx.add(t_import.int_import("/fs/testData/rqRange/in/qMatMul_0.idx", "a"));
-    ctx.add(t_import.float_import("/fs/testData/rqRange/in/qMatMul_1.idx", "a_min"));
-    ctx.add(t_import.float_import("/fs/testData/rqRange/in/qMatMul_2.idx", "a_max"));
+    ctx.add(defer(t_import.int_import("/fs/testData/rqRange/in/qMatMul_0.idx", "a")));
+    ctx.add(defer(t_import.float_import("/fs/testData/rqRange/in/qMatMul_1.idx", "a_min")));
+    ctx.add(defer(t_import.float_import("/fs/testData/rqRange/in/qMatMul_2.idx", "a_max")));
 
     // reference output
-    ctx.add(t_import.float_import("/fs/testData/rqRange/out/rqRange_0.idx", "ref_min"));
-    ctx.add(t_import.float_import("/fs/testData/rqRange/out/rqRange_1.idx", "ref_max"));
+    ctx.add(defer(t_import.float_import("/fs/testData/rqRange/out/rqRange_0.idx", "ref_min")));
+    ctx.add(defer(t_import.float_import("/fs/testData/rqRange/out/rqRange_1.idx", "ref_max")));
 
     // Implementation goes here
 
     // modify the checks below:
-    ctx.add(new RamTensor<float>(ctx.get("ref_min")->getShape(), "out_min"));
-    ctx.add(new RamTensor<float>(ctx.get("ref_max")->getShape(), "out_max"));
+    ctx.add(defer(new RamTensor<float>(ctx.get("ref_min")->getShape(), "out_min")));
+    ctx.add(defer(new RamTensor<float>(ctx.get("ref_max")->getShape(), "out_max")));
     TNameList inputs = {"a", "a_min", "a_max"};
     TNameList outputs = {"out_min", "out_max"};
     
     timer_start();
-    ctx.push(new Requantization_RangeOp(), inputs, outputs);
+    ctx.push(defer(new Requantization_RangeOp()), inputs, outputs);
     ctx.eval();
     timer_stop();
 
@@ -52,25 +52,25 @@ class MathOpsTest : public Test {
     ctx.gc();
 
     // reference inputs
-    ctx.add(t_import.int_import("/fs/testData/rQ/in/qMatMul_0.idx", "a"));
-    ctx.add(t_import.float_import("/fs/testData/rQ/in/qMatMul_1.idx", "a_min"));
-    ctx.add(t_import.float_import("/fs/testData/rQ/in/qMatMul_2.idx", "a_max"));
-    ctx.add(t_import.float_import("/fs/testData/rQ/in/rqRange_0.idx", "r_a_min"));
-    ctx.add(t_import.float_import("/fs/testData/rQ/in/rqRange_1.idx", "r_a_max"));
+    ctx.add(defer(t_import.int_import("/fs/testData/rQ/in/qMatMul_0.idx", "a")));
+    ctx.add(defer(t_import.float_import("/fs/testData/rQ/in/qMatMul_1.idx", "a_min")));
+    ctx.add(defer(t_import.float_import("/fs/testData/rQ/in/qMatMul_2.idx", "a_max")));
+    ctx.add(defer(t_import.float_import("/fs/testData/rQ/in/rqRange_0.idx", "r_a_min")));
+    ctx.add(defer(t_import.float_import("/fs/testData/rQ/in/rqRange_1.idx", "r_a_max")));
     // tf.quint8
 
     //Note:
     //Instead of using ctx.get() to obtain a shared_ptr, you may also use the shared_ptr returned by ctx.add()
 
     // reference outputs
-    S_TENSOR ref_a_q = ctx.add(t_import.ubyte_import("/fs/testData/rQ/out/rQ_0.idx", "ref_a_q"));
-    S_TENSOR ref_a_min = ctx.add(t_import.float_import("/fs/testData/rQ/out/rQ_1.idx", "ref_a_min"));
-    S_TENSOR ref_a_max = ctx.add(t_import.float_import("/fs/testData/rQ/out/rQ_2.idx", "ref_a_max"));
+    S_TENSOR ref_a_q = ctx.add(defer(t_import.ubyte_import("/fs/testData/rQ/out/rQ_0.idx", "ref_a_q")));
+    S_TENSOR ref_a_min = ctx.add(defer(t_import.float_import("/fs/testData/rQ/out/rQ_1.idx", "ref_a_min")));
+    S_TENSOR ref_a_max = ctx.add(defer(t_import.float_import("/fs/testData/rQ/out/rQ_2.idx", "ref_a_max")));
 
     // modify the checks below:
-    S_TENSOR a_q = ctx.add(new RamTensor<unsigned char>(ref_a_q->getShape(), "a_q"));
-    S_TENSOR a_min_q = ctx.add(new RamTensor<float>(ref_a_min->getShape(), "a_min_q"));
-    S_TENSOR a_max_q = ctx.add(new RamTensor<float>(ref_a_max->getShape(), "a_max_q"));
+    S_TENSOR a_q = ctx.add(defer(new RamTensor<unsigned char>(ref_a_q->getShape(), "a_q")));
+    S_TENSOR a_min_q = ctx.add(defer(new RamTensor<float>(ref_a_min->getShape(), "a_min_q")));
+    S_TENSOR a_max_q = ctx.add(defer(new RamTensor<float>(ref_a_max->getShape(), "a_max_q")));
 
 
     TNameList inputs = {"a", "a_min", "a_max", "r_a_min", "r_a_max"};
@@ -78,7 +78,7 @@ class MathOpsTest : public Test {
 
     // Implementation goes here
     timer_start();
-    ctx.push(new RequantizeOp(), inputs, outputs);
+    ctx.push(defer(new RequantizeOp()), inputs, outputs);
     ctx.eval();
     timer_stop();
 
@@ -95,23 +95,23 @@ class MathOpsTest : public Test {
     ctx.gc();
 
     // reference inputs
-    ctx.add(t_import.int_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_quantized_mat_mul_0.idx", "a"));
-    ctx.add(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_quantized_mat_mul_1.idx", "a_min"));
-    ctx.add(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_quantized_mat_mul_2.idx", "a_max"));
-    ctx.add(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_requant_range_0.idx", "r_a_min"));
-    ctx.add(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_requant_range_1.idx", "r_a_max"));
+    ctx.add(defer(t_import.int_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_quantized_mat_mul_0.idx", "a")));
+    ctx.add(defer(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_quantized_mat_mul_1.idx", "a_min")));
+    ctx.add(defer(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_quantized_mat_mul_2.idx", "a_max")));
+    ctx.add(defer(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_requant_range_0.idx", "r_a_min")));
+    ctx.add(defer(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_requant_range_1.idx", "r_a_max")));
     // tf.quint8
 
     // reference outputs
-    ctx.add(t_import.ubyte_import("/fs/testData/import-MatMul_eightbit_requantize/out/import-MatMul_eightbit_requantize_0.idx", "ref_a_q"));
-    ctx.add(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/out/import-MatMul_eightbit_requantize_1.idx", "ref_a_min"));
-    ctx.add(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/out/import-MatMul_eightbit_requantize_2.idx", "ref_a_max"));
+    ctx.add(defer(t_import.ubyte_import("/fs/testData/import-MatMul_eightbit_requantize/out/import-MatMul_eightbit_requantize_0.idx", "ref_a_q")));
+    ctx.add(defer(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/out/import-MatMul_eightbit_requantize_1.idx", "ref_a_min")));
+    ctx.add(defer(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/out/import-MatMul_eightbit_requantize_2.idx", "ref_a_max")));
 
     
     // modify the checks below:
-    ctx.add(new RamTensor<unsigned char>(ctx.get("ref_a_q")->getShape(), "a_q"));
-    ctx.add(new RamTensor<float>(ctx.get("ref_a_min")->getShape(), "a_min_q"));
-    ctx.add(new RamTensor<float>(ctx.get("ref_a_max")->getShape(), "a_max_q"));
+    ctx.add(defer(new RamTensor<unsigned char>(ctx.get("ref_a_q")->getShape(), "a_q")));
+    ctx.add(defer(new RamTensor<float>(ctx.get("ref_a_min")->getShape(), "a_min_q")));
+    ctx.add(defer(new RamTensor<float>(ctx.get("ref_a_max")->getShape(), "a_max_q")));
 
     S_TENSOR ref_val = ctx.get("ref_a_q");
     S_TENSOR ref_min = ctx.get("ref_a_min");
@@ -122,7 +122,7 @@ class MathOpsTest : public Test {
 
     // Implementation goes here
     timer_start();
-    ctx.push(new RequantizeOp(), {"a", "a_min", "a_max", "r_a_min", "r_a_max"}, {"a_q", "a_min_q", "a_max_q"});
+    ctx.push(defer(new RequantizeOp()), {"a", "a_min", "a_max", "r_a_min", "r_a_max"}, {"a_q", "a_min_q", "a_max_q"});
     ctx.eval();
     timer_stop();
 
@@ -158,24 +158,24 @@ class MathOpsTest : public Test {
     ctx.gc();
 
     // reference inputs
-    ctx.add(t_import.float_import("/fs/testData/ArgMax/in/ArgMax-input_0.idx", "ref_a"));
-    ctx.add(t_import.int_import("/fs/testData/ArgMax/in/ArgMax-dimension_0.idx", "ref_dim"));
+    ctx.add(defer(t_import.float_import("/fs/testData/ArgMax/in/ArgMax-input_0.idx", "ref_a")));
+    ctx.add(defer(t_import.int_import("/fs/testData/ArgMax/in/ArgMax-dimension_0.idx", "ref_dim")));
 
     // reference outputs
     /// NT: FIXME: argmax outputs int64 tensor which isn't supported by
     /// int_import.
-    S_TENSOR ref_out = ctx.add(t_import.float_import("/fs/testData/ArgMax/out/ArgMax_0.idx", "ref_out"));
+    S_TENSOR ref_out = ctx.add(defer(t_import.float_import("/fs/testData/ArgMax/out/ArgMax_0.idx", "ref_out")));
 
     // Implementation goes here
 
     // modify the checks below:
-    S_TENSOR out = ctx.add(new RamTensor<int>(ref_out->getShape(), "out"));
+    S_TENSOR out = ctx.add(defer(new RamTensor<int>(ref_out->getShape(), "out")));
     
     TNameList inputs = {"ref_a", "ref_dim"};
     TNameList outputs = {"out"};
 
     timer_start();
-    ctx.push(new ArgMaxOp<float, int>(), inputs, outputs);
+    ctx.push(defer(new ArgMaxOp<float, int>()), inputs, outputs);
     ctx.eval();
     timer_stop();
     
@@ -192,29 +192,29 @@ class MathOpsTest : public Test {
 
     ctx.gc();
 
-    S_TENSOR test_input = ctx.add(TensorConstant<float>({10, 5}, 0.0f, "test_input"));
+    S_TENSOR test_input = ctx.add(defer(TensorConstant<float>({10, 5}, 0.0f, "test_input")));
     *(test_input->write<float>(25, 0)) = 1.0f;
     *(test_input->write<float>(26, 0)) = 1.0f;
     *(test_input->write<float>(7, 0))  = 1.0f;
     *(test_input->write<float>(48, 0)) = 1.0f;
     *(test_input->write<float>(14, 0)) = 1.0f;
 
-    S_TENSOR test_dim = ctx.add(new RamTensor<int>({1}, "test_dim"));
+    S_TENSOR test_dim = ctx.add(defer(new RamTensor<int>({1}, "test_dim")));
     *(test_dim->write<int>(0, 0)) = 0;
 
-    S_TENSOR test_out_ref = ctx.add(new RamTensor<float>({5}, "test_out_ref"));
+    S_TENSOR test_out_ref = ctx.add(defer(new RamTensor<float>({5}, "test_out_ref")));
     *(test_out_ref->write<float>(0, 0)) = 5.0f;
     *(test_out_ref->write<float>(1, 0)) = 5.0f;
     *(test_out_ref->write<float>(2, 0)) = 1.0f;
     *(test_out_ref->write<float>(3, 0)) = 9.0f;
     *(test_out_ref->write<float>(4, 0)) = 2.0f;
 
-    S_TENSOR test_out = ctx.add(new RamTensor<float>(test_out_ref->getShape(), "test_out"));
+    S_TENSOR test_out = ctx.add(defer(new RamTensor<float>(test_out_ref->getShape(), "test_out")));
     TNameList inputs = {"test_input", "test_dim"};
     TNameList outputs = {"test_out"};
 
     timer_start();
-    ctx.push(new ArgMaxOp<float, float>(), inputs, outputs);
+    ctx.push(defer(new ArgMaxOp<float, float>()), inputs, outputs);
     ctx.eval();
     timer_stop();
 
@@ -227,20 +227,20 @@ class MathOpsTest : public Test {
     testStart("add");
 
     // reference inputs
-    ctx.add(t_import.float_import("/fs/testData/ref_add/in/Const_5_0.idx", "a"));
-    ctx.add(t_import.float_import("/fs/testData/ref_add/in/Const_6_0.idx", "b"));
+    ctx.add(defer(t_import.float_import("/fs/testData/ref_add/in/Const_5_0.idx", "a")));
+    ctx.add(defer(t_import.float_import("/fs/testData/ref_add/in/Const_6_0.idx", "b")));
 
     // reference outputs
-    S_TENSOR ref_out = ctx.add(t_import.float_import("/fs/testData/ref_add/out/ref_add_0.idx", "ref_out"));
+    S_TENSOR ref_out = ctx.add(defer(t_import.float_import("/fs/testData/ref_add/out/ref_add_0.idx", "ref_out")));
 
     // Implementation goes here
 
     // modify the checks below:
-    S_TENSOR out = ctx.add(new RamTensor<float>(ref_out->getShape(), "out"));
+    S_TENSOR out = ctx.add(defer(new RamTensor<float>(ref_out->getShape(), "out")));
     TNameList inputs = {"a", "b"};
     TNameList outputs = {"out"};
     timer_start();
-    ctx.push(new AddOp<float, float>(), inputs, outputs);
+    ctx.push(defer(new AddOp<float, float>()), inputs, outputs);
     ctx.eval();
     timer_stop();
 
@@ -255,21 +255,21 @@ class MathOpsTest : public Test {
     ctx.gc();
 
     // reference inputs
-    ctx.add(t_import.float_import("/fs/testData/ref_min/in/Const_2_0.idx", "a"));
-    ctx.add(t_import.int_import("/fs/testData/ref_min/in/Const_3_0.idx", "dim"));
+    ctx.add(defer(t_import.float_import("/fs/testData/ref_min/in/Const_2_0.idx", "a")));
+    ctx.add(defer(t_import.int_import("/fs/testData/ref_min/in/Const_3_0.idx", "dim")));
 
     // reference outputs
-    S_TENSOR ref_out = ctx.add(t_import.float_import("/fs/testData/ref_min/out/ref_min_0.idx", "ref_out"));
+    S_TENSOR ref_out = ctx.add(defer(t_import.float_import("/fs/testData/ref_min/out/ref_min_0.idx", "ref_out")));
 
     // Implementation goes here
 
     // modify the checks below:
-    S_TENSOR out = ctx.add(new RamTensor<float>(ref_out->getShape(), "out"));
+    S_TENSOR out = ctx.add(defer(new RamTensor<float>(ref_out->getShape(), "out")));
     TNameList inputs = {"a", "dim"};
     TNameList outputs = {"out"};
 
     timer_start();
-    ctx.push(new MinOp(), inputs, outputs);
+    ctx.push(defer(new MinOp()), inputs, outputs);
     ctx.eval();
     timer_stop();
 
@@ -284,20 +284,20 @@ class MathOpsTest : public Test {
     ctx.gc();
 
     // reference inputs
-    ctx.add(t_import.float_import("/fs/testData/ref_max/in/Const_2_0.idx", "a"));
-    ctx.add(t_import.int_import("/fs/testData/ref_max/in/Const_4_0.idx", "dim"));
+    ctx.add(defer(t_import.float_import("/fs/testData/ref_max/in/Const_2_0.idx", "a")));
+    ctx.add(defer(t_import.int_import("/fs/testData/ref_max/in/Const_4_0.idx", "dim")));
 
     // reference outputs
-    S_TENSOR ref_out = ctx.add(t_import.float_import("/fs/testData/ref_max/out/ref_max_0.idx", "ref_out"));
+    S_TENSOR ref_out = ctx.add(defer(t_import.float_import("/fs/testData/ref_max/out/ref_max_0.idx", "ref_out")));
 
     // Implementation goes here
 
     // modify the checks below:
-    S_TENSOR out = ctx.add(new RamTensor<float>(ref_out->getShape(), "out"));
+    S_TENSOR out = ctx.add(defer(new RamTensor<float>(ref_out->getShape(), "out")));
     TNameList inputs = {"a", "dim"};
     TNameList outputs = {"out"};
     timer_start();
-    ctx.push(new MaxOp(), inputs, outputs);
+    ctx.push(defer(new MaxOp()), inputs, outputs);
     ctx.eval();
     timer_stop();
 

--- a/MathTests.hpp
+++ b/MathTests.hpp
@@ -17,24 +17,24 @@ class MathOpsTest : public Test {
 
     //Note: raw pointers should be owned ONLY by the context. no copy of the raw pointer should exist elsewhere
     // reference inputs
-    ctx.add(defer(t_import.int_import("/fs/testData/rqRange/in/qMatMul_0.idx", "a")));
-    ctx.add(defer(t_import.float_import("/fs/testData/rqRange/in/qMatMul_1.idx", "a_min")));
-    ctx.add(defer(t_import.float_import("/fs/testData/rqRange/in/qMatMul_2.idx", "a_max")));
+    ctx.addCached(hold(t_import.int_import("/fs/testData/rqRange/in/qMatMul_0.idx")), "a");
+    ctx.addCached(hold(t_import.float_import("/fs/testData/rqRange/in/qMatMul_1.idx")), "a_min");
+    ctx.addCached(hold(t_import.float_import("/fs/testData/rqRange/in/qMatMul_2.idx")), "a_max");
 
     // reference output
-    ctx.add(defer(t_import.float_import("/fs/testData/rqRange/out/rqRange_0.idx", "ref_min")));
-    ctx.add(defer(t_import.float_import("/fs/testData/rqRange/out/rqRange_1.idx", "ref_max")));
+    ctx.addCached(hold(t_import.float_import("/fs/testData/rqRange/out/rqRange_0.idx")), "ref_min");
+    ctx.addCached(hold(t_import.float_import("/fs/testData/rqRange/out/rqRange_1.idx")), "ref_max");
 
     // Implementation goes here
 
     // modify the checks below:
-    ctx.add(defer(new RamTensor<float>(ctx.get("ref_min")->getShape(), "out_min")));
-    ctx.add(defer(new RamTensor<float>(ctx.get("ref_max")->getShape(), "out_max")));
+    ctx.addCached(hold(new RamTensor<float>(ctx.get("ref_min")->getShape())), "out_min");
+    ctx.addCached(hold(new RamTensor<float>(ctx.get("ref_max")->getShape())), "out_max");
     TNameList inputs = {"a", "a_min", "a_max"};
     TNameList outputs = {"out_min", "out_max"};
     
     timer_start();
-    ctx.push(defer(new Requantization_RangeOp()), inputs, outputs);
+    ctx.push_static(hold(new Requantization_RangeOp()), "Requantization_RangeOp", inputs, outputs);
     ctx.eval();
     timer_stop();
 
@@ -52,25 +52,25 @@ class MathOpsTest : public Test {
     ctx.gc();
 
     // reference inputs
-    ctx.add(defer(t_import.int_import("/fs/testData/rQ/in/qMatMul_0.idx", "a")));
-    ctx.add(defer(t_import.float_import("/fs/testData/rQ/in/qMatMul_1.idx", "a_min")));
-    ctx.add(defer(t_import.float_import("/fs/testData/rQ/in/qMatMul_2.idx", "a_max")));
-    ctx.add(defer(t_import.float_import("/fs/testData/rQ/in/rqRange_0.idx", "r_a_min")));
-    ctx.add(defer(t_import.float_import("/fs/testData/rQ/in/rqRange_1.idx", "r_a_max")));
+    ctx.addCached(hold(t_import.int_import("/fs/testData/rQ/in/qMatMul_0.idx")), "a");
+    ctx.addCached(hold(t_import.float_import("/fs/testData/rQ/in/qMatMul_1.idx")), "a_min");
+    ctx.addCached(hold(t_import.float_import("/fs/testData/rQ/in/qMatMul_2.idx")), "a_max");
+    ctx.addCached(hold(t_import.float_import("/fs/testData/rQ/in/rqRange_0.idx")), "r_a_min");
+    ctx.addCached(hold(t_import.float_import("/fs/testData/rQ/in/rqRange_1.idx")), "r_a_max");
     // tf.quint8
 
     //Note:
     //Instead of using ctx.get() to obtain a shared_ptr, you may also use the shared_ptr returned by ctx.add()
 
     // reference outputs
-    S_TENSOR ref_a_q = ctx.add(defer(t_import.ubyte_import("/fs/testData/rQ/out/rQ_0.idx", "ref_a_q")));
-    S_TENSOR ref_a_min = ctx.add(defer(t_import.float_import("/fs/testData/rQ/out/rQ_1.idx", "ref_a_min")));
-    S_TENSOR ref_a_max = ctx.add(defer(t_import.float_import("/fs/testData/rQ/out/rQ_2.idx", "ref_a_max")));
+    S_TENSOR ref_a_q = ctx.addCached(hold(t_import.ubyte_import("/fs/testData/rQ/out/rQ_0.idx")), "ref_a_q");
+    S_TENSOR ref_a_min = ctx.addCached(hold(t_import.float_import("/fs/testData/rQ/out/rQ_1.idx")), "ref_a_min");
+    S_TENSOR ref_a_max = ctx.addCached(hold(t_import.float_import("/fs/testData/rQ/out/rQ_2.idx")), "ref_a_max");
 
     // modify the checks below:
-    S_TENSOR a_q = ctx.add(defer(new RamTensor<unsigned char>(ref_a_q->getShape(), "a_q")));
-    S_TENSOR a_min_q = ctx.add(defer(new RamTensor<float>(ref_a_min->getShape(), "a_min_q")));
-    S_TENSOR a_max_q = ctx.add(defer(new RamTensor<float>(ref_a_max->getShape(), "a_max_q")));
+    S_TENSOR a_q = ctx.addCached(hold(new RamTensor<unsigned char>(ref_a_q->getShape())), "a_q");
+    S_TENSOR a_min_q = ctx.addCached(hold(new RamTensor<float>(ref_a_min->getShape())), "a_min_q");
+    S_TENSOR a_max_q = ctx.addCached(hold(new RamTensor<float>(ref_a_max->getShape())), "a_max_q");
 
 
     TNameList inputs = {"a", "a_min", "a_max", "r_a_min", "r_a_max"};
@@ -78,7 +78,7 @@ class MathOpsTest : public Test {
 
     // Implementation goes here
     timer_start();
-    ctx.push(defer(new RequantizeOp()), inputs, outputs);
+    ctx.push_static(hold(new RequantizeOp()), "RequantizeOp", inputs, outputs);
     ctx.eval();
     timer_stop();
 
@@ -95,23 +95,23 @@ class MathOpsTest : public Test {
     ctx.gc();
 
     // reference inputs
-    ctx.add(defer(t_import.int_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_quantized_mat_mul_0.idx", "a")));
-    ctx.add(defer(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_quantized_mat_mul_1.idx", "a_min")));
-    ctx.add(defer(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_quantized_mat_mul_2.idx", "a_max")));
-    ctx.add(defer(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_requant_range_0.idx", "r_a_min")));
-    ctx.add(defer(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_requant_range_1.idx", "r_a_max")));
+    ctx.addCached(hold(t_import.int_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_quantized_mat_mul_0.idx")), "a");
+    ctx.addCached(hold(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_quantized_mat_mul_1.idx")), "a_min");
+    ctx.addCached(hold(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_quantized_mat_mul_2.idx")), "a_max");
+    ctx.addCached(hold(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_requant_range_0.idx")), "r_a_min");
+    ctx.addCached(hold(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/in/import-MatMul_eightbit_requant_range_1.idx")), "r_a_max");
     // tf.quint8
 
     // reference outputs
-    ctx.add(defer(t_import.ubyte_import("/fs/testData/import-MatMul_eightbit_requantize/out/import-MatMul_eightbit_requantize_0.idx", "ref_a_q")));
-    ctx.add(defer(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/out/import-MatMul_eightbit_requantize_1.idx", "ref_a_min")));
-    ctx.add(defer(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/out/import-MatMul_eightbit_requantize_2.idx", "ref_a_max")));
+    ctx.addCached(hold(t_import.ubyte_import("/fs/testData/import-MatMul_eightbit_requantize/out/import-MatMul_eightbit_requantize_0.idx")), "ref_a_q");
+    ctx.addCached(hold(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/out/import-MatMul_eightbit_requantize_1.idx")), "ref_a_min");
+    ctx.addCached(hold(t_import.float_import("/fs/testData/import-MatMul_eightbit_requantize/out/import-MatMul_eightbit_requantize_2.idx")), "ref_a_max");
 
     
     // modify the checks below:
-    ctx.add(defer(new RamTensor<unsigned char>(ctx.get("ref_a_q")->getShape(), "a_q")));
-    ctx.add(defer(new RamTensor<float>(ctx.get("ref_a_min")->getShape(), "a_min_q")));
-    ctx.add(defer(new RamTensor<float>(ctx.get("ref_a_max")->getShape(), "a_max_q")));
+    ctx.addCached(hold(new RamTensor<unsigned char>(ctx.get("ref_a_q")->getShape())), "a_q");
+    ctx.addCached(hold(new RamTensor<float>(ctx.get("ref_a_min")->getShape())), "a_min_q");
+    ctx.addCached(hold(new RamTensor<float>(ctx.get("ref_a_max")->getShape())), "a_max_q");
 
     S_TENSOR ref_val = ctx.get("ref_a_q");
     S_TENSOR ref_min = ctx.get("ref_a_min");
@@ -122,7 +122,7 @@ class MathOpsTest : public Test {
 
     // Implementation goes here
     timer_start();
-    ctx.push(defer(new RequantizeOp()), {"a", "a_min", "a_max", "r_a_min", "r_a_max"}, {"a_q", "a_min_q", "a_max_q"});
+    ctx.push_static(hold(new RequantizeOp()), "RequantizeOp", {"a", "a_min", "a_max", "r_a_min", "r_a_max"}, {"a_q", "a_min_q", "a_max_q"});
     ctx.eval();
     timer_stop();
 
@@ -158,28 +158,28 @@ class MathOpsTest : public Test {
     ctx.gc();
 
     // reference inputs
-    ctx.add(defer(t_import.float_import("/fs/testData/ArgMax/in/ArgMax-input_0.idx", "ref_a")));
-    ctx.add(defer(t_import.int_import("/fs/testData/ArgMax/in/ArgMax-dimension_0.idx", "ref_dim")));
+    ctx.addCached(hold(t_import.float_import("/fs/testData/ArgMax/in/ArgMax-input_0.idx")), "ref_a");
+    ctx.addCached(hold(t_import.int_import("/fs/testData/ArgMax/in/ArgMax-dimension_0.idx")), "ref_dim");
 
     // reference outputs
     /// NT: FIXME: argmax outputs int64 tensor which isn't supported by
     /// int_import.
-    S_TENSOR ref_out = ctx.add(defer(t_import.float_import("/fs/testData/ArgMax/out/ArgMax_0.idx", "ref_out")));
+    S_TENSOR ref_out = ctx.addCached(hold(t_import.float_import("/fs/testData/ArgMax/out/ArgMax_0.idx")), "ref_out");
 
     // Implementation goes here
 
     // modify the checks below:
-    S_TENSOR out = ctx.add(defer(new RamTensor<int>(ref_out->getShape(), "out")));
+    S_TENSOR out = ctx.addCached(hold(new RamTensor<int>(ref_out->getShape())), "out");
     
     TNameList inputs = {"ref_a", "ref_dim"};
     TNameList outputs = {"out"};
 
     timer_start();
-    ctx.push(defer(new ArgMaxOp<float, int>()), inputs, outputs);
+    ctx.push_static(hold(new ArgMaxOp<float, int>()), "ArgMaxOp", inputs, outputs);
     ctx.eval();
     timer_stop();
     
-    Tensor* out_float = TensorCast<int, float>(out.get(), "out_float");  ///NT: /WIP  how to handle the name?
+    Tensor* out_float = TensorCast<int, float>(out.get());  ///NT: /WIP  how to handle the name?
 
     double result = meanPercentErr<float>(ref_out.get(), out_float);
 
@@ -192,29 +192,29 @@ class MathOpsTest : public Test {
 
     ctx.gc();
 
-    S_TENSOR test_input = ctx.add(defer(TensorConstant<float>({10, 5}, 0.0f, "test_input")));
+    S_TENSOR test_input = ctx.add(TensorConstant<float>({10, 5}, 0.0f), "test_input");
     *(test_input->write<float>(25, 0)) = 1.0f;
     *(test_input->write<float>(26, 0)) = 1.0f;
     *(test_input->write<float>(7, 0))  = 1.0f;
     *(test_input->write<float>(48, 0)) = 1.0f;
     *(test_input->write<float>(14, 0)) = 1.0f;
 
-    S_TENSOR test_dim = ctx.add(defer(new RamTensor<int>({1}, "test_dim")));
+    S_TENSOR test_dim = ctx.add(new RamTensor<int>({1}), "test_dim");
     *(test_dim->write<int>(0, 0)) = 0;
 
-    S_TENSOR test_out_ref = ctx.add(defer(new RamTensor<float>({5}, "test_out_ref")));
+    S_TENSOR test_out_ref = ctx.add(new RamTensor<float>({5}), "test_out_ref");
     *(test_out_ref->write<float>(0, 0)) = 5.0f;
     *(test_out_ref->write<float>(1, 0)) = 5.0f;
     *(test_out_ref->write<float>(2, 0)) = 1.0f;
     *(test_out_ref->write<float>(3, 0)) = 9.0f;
     *(test_out_ref->write<float>(4, 0)) = 2.0f;
 
-    S_TENSOR test_out = ctx.add(defer(new RamTensor<float>(test_out_ref->getShape(), "test_out")));
+    S_TENSOR test_out = ctx.add(new RamTensor<float>(test_out_ref->getShape()), "test_out");
     TNameList inputs = {"test_input", "test_dim"};
     TNameList outputs = {"test_out"};
 
     timer_start();
-    ctx.push(defer(new ArgMaxOp<float, float>()), inputs, outputs);
+    ctx.push(new ArgMaxOp<float, float>(), inputs, outputs);
     ctx.eval();
     timer_stop();
 
@@ -227,20 +227,20 @@ class MathOpsTest : public Test {
     testStart("add");
 
     // reference inputs
-    ctx.add(defer(t_import.float_import("/fs/testData/ref_add/in/Const_5_0.idx", "a")));
-    ctx.add(defer(t_import.float_import("/fs/testData/ref_add/in/Const_6_0.idx", "b")));
+    ctx.addCached(hold(t_import.float_import("/fs/testData/ref_add/in/Const_5_0.idx")), "a");
+    ctx.addCached(hold(t_import.float_import("/fs/testData/ref_add/in/Const_6_0.idx")), "b");
 
     // reference outputs
-    S_TENSOR ref_out = ctx.add(defer(t_import.float_import("/fs/testData/ref_add/out/ref_add_0.idx", "ref_out")));
+    S_TENSOR ref_out = ctx.addCached(hold(t_import.float_import("/fs/testData/ref_add/out/ref_add_0.idx")), "ref_out");
 
     // Implementation goes here
 
     // modify the checks below:
-    S_TENSOR out = ctx.add(defer(new RamTensor<float>(ref_out->getShape(), "out")));
+    S_TENSOR out = ctx.addCached(hold(new RamTensor<float>(ref_out->getShape())), "out");
     TNameList inputs = {"a", "b"};
     TNameList outputs = {"out"};
     timer_start();
-    ctx.push(defer(new AddOp<float, float>()), inputs, outputs);
+    ctx.push_static(hold(new AddOp<float, float>()), "AddOp", inputs, outputs);
     ctx.eval();
     timer_stop();
 
@@ -255,21 +255,21 @@ class MathOpsTest : public Test {
     ctx.gc();
 
     // reference inputs
-    ctx.add(defer(t_import.float_import("/fs/testData/ref_min/in/Const_2_0.idx", "a")));
-    ctx.add(defer(t_import.int_import("/fs/testData/ref_min/in/Const_3_0.idx", "dim")));
+    ctx.addCached(hold(t_import.float_import("/fs/testData/ref_min/in/Const_2_0.idx")), "a");
+    ctx.addCached(hold(t_import.int_import("/fs/testData/ref_min/in/Const_3_0.idx")), "dim");
 
     // reference outputs
-    S_TENSOR ref_out = ctx.add(defer(t_import.float_import("/fs/testData/ref_min/out/ref_min_0.idx", "ref_out")));
+    S_TENSOR ref_out = ctx.addCached(hold(t_import.float_import("/fs/testData/ref_min/out/ref_min_0.idx")), "ref_out");
 
     // Implementation goes here
 
     // modify the checks below:
-    S_TENSOR out = ctx.add(defer(new RamTensor<float>(ref_out->getShape(), "out")));
+    S_TENSOR out = ctx.addCached(hold(new RamTensor<float>(ref_out->getShape())), "out");
     TNameList inputs = {"a", "dim"};
     TNameList outputs = {"out"};
 
     timer_start();
-    ctx.push(defer(new MinOp()), inputs, outputs);
+    ctx.push_static(hold(new MinOp()), "MinOp", inputs, outputs);
     ctx.eval();
     timer_stop();
 
@@ -284,20 +284,20 @@ class MathOpsTest : public Test {
     ctx.gc();
 
     // reference inputs
-    ctx.add(defer(t_import.float_import("/fs/testData/ref_max/in/Const_2_0.idx", "a")));
-    ctx.add(defer(t_import.int_import("/fs/testData/ref_max/in/Const_4_0.idx", "dim")));
+    ctx.addCached(hold(t_import.float_import("/fs/testData/ref_max/in/Const_2_0.idx")), "a");
+    ctx.addCached(hold(t_import.int_import("/fs/testData/ref_max/in/Const_4_0.idx")), "dim");
 
     // reference outputs
-    S_TENSOR ref_out = ctx.add(defer(t_import.float_import("/fs/testData/ref_max/out/ref_max_0.idx", "ref_out")));
+    S_TENSOR ref_out = ctx.addCached(hold(t_import.float_import("/fs/testData/ref_max/out/ref_max_0.idx")), "ref_out");
 
     // Implementation goes here
 
     // modify the checks below:
-    S_TENSOR out = ctx.add(defer(new RamTensor<float>(ref_out->getShape(), "out")));
+    S_TENSOR out = ctx.addCached(hold(new RamTensor<float>(ref_out->getShape())), "out");
     TNameList inputs = {"a", "dim"};
     TNameList outputs = {"out"};
     timer_start();
-    ctx.push(defer(new MaxOp()), inputs, outputs);
+    ctx.push_static(hold(new MaxOp()), "MaxOp", inputs, outputs);
     ctx.eval();
     timer_stop();
 

--- a/MatrixTests.hpp
+++ b/MatrixTests.hpp
@@ -17,24 +17,24 @@ class matrixOpsTest : public Test {
     ctx.gc();
 
     //inputs
-    ctx.add(t_import.ubyte_import("/fs/testData/qMatMul/in/qA_0.idx", "a"));
-    ctx.add(t_import.float_import("/fs/testData/qMatMul/in/qA_1.idx", "a_min"));
-    ctx.add(t_import.float_import("/fs/testData/qMatMul/in/qA_2.idx", "a_max"));
-    ctx.add(t_import.ubyte_import("/fs/testData/qMatMul/in/qB_0.idx", "b"));
-    ctx.add(t_import.float_import("/fs/testData/qMatMul/in/qB_1.idx", "b_min"));
-    ctx.add(t_import.float_import("/fs/testData/qMatMul/in/qB_2.idx", "b_max"));
+    ctx.add(t_import.ubyte_import("/fs/testData/qMatMul/in/qA_0.idx"), "a");
+    ctx.add(t_import.float_import("/fs/testData/qMatMul/in/qA_1.idx"), "a_min");
+    ctx.add(t_import.float_import("/fs/testData/qMatMul/in/qA_2.idx"), "a_max");
+    ctx.add(t_import.ubyte_import("/fs/testData/qMatMul/in/qB_0.idx"), "b");
+    ctx.add(t_import.float_import("/fs/testData/qMatMul/in/qB_1.idx"), "b_min");
+    ctx.add(t_import.float_import("/fs/testData/qMatMul/in/qB_2.idx"), "b_max");
 
     // reference outputs
-    S_TENSOR c = ctx.add(t_import.int_import("/fs/testData/qMatMul/out/qMatMul_0.idx", "c"));
-    S_TENSOR c_min = ctx.add(t_import.float_import("/fs/testData/qMatMul/out/qMatMul_1.idx", "c_min"));
-    S_TENSOR c_max = ctx.add(t_import.float_import("/fs/testData/qMatMul/out/qMatMul_2.idx", "c_max"));
+    S_TENSOR c = ctx.add(t_import.int_import("/fs/testData/qMatMul/out/qMatMul_0.idx"), "c");
+    S_TENSOR c_min = ctx.add(t_import.float_import("/fs/testData/qMatMul/out/qMatMul_1.idx"), "c_min");
+    S_TENSOR c_max = ctx.add(t_import.float_import("/fs/testData/qMatMul/out/qMatMul_2.idx"), "c_max");
 
 
     //we need default constructor here
     //so we can get ride of the shapes here
-    S_TENSOR out_c = ctx.add(new RamTensor<int>(c->getShape(), "out_c"));
-    S_TENSOR out_min = ctx.add(new RamTensor<float>(c_min->getShape(), "out_min"));
-    S_TENSOR out_max = ctx.add(new RamTensor<float>(c_max->getShape(), "out_max"));
+    S_TENSOR out_c = ctx.add(new RamTensor<int>(c->getShape()), "out_c");
+    S_TENSOR out_min = ctx.add(new RamTensor<float>(c_min->getShape()), "out_min");
+    S_TENSOR out_max = ctx.add(new RamTensor<float>(c_max->getShape()), "out_max");
 
     //TList inputs = {a, a_min, a_max, b, b_min, b_max};
     //TList outputs = {out_c, out_min, out_max};

--- a/NnTests.hpp
+++ b/NnTests.hpp
@@ -14,24 +14,24 @@ class NnOpsTest : public Test {
     testStart("quantized_relu");
     // reference inputs
     S_TENSOR a =
-        ctx.add(t_import.ubyte_import("/fs/testData/ref_qRelu/in/QuantizeV2_0.idx", "a"));
+        ctx.add(t_import.ubyte_import("/fs/testData/ref_qRelu/in/QuantizeV2_0.idx"), "a");
     S_TENSOR min =
-        ctx.add(t_import.float_import("/fs/testData/ref_qRelu/in/QuantizeV2_1.idx", "min"));
+        ctx.add(t_import.float_import("/fs/testData/ref_qRelu/in/QuantizeV2_1.idx"), "min");
     S_TENSOR max =
-        ctx.add(t_import.float_import("/fs/testData/ref_qRelu/in/QuantizeV2_2.idx", "max"));
+        ctx.add(t_import.float_import("/fs/testData/ref_qRelu/in/QuantizeV2_2.idx"), "max");
 
     // reference outputs
     S_TENSOR ref_out =
-        ctx.add(t_import.ubyte_import("/fs/testData/ref_qRelu/out/ref_qRelu_0.idx", "ref_out"));
+        ctx.add(t_import.ubyte_import("/fs/testData/ref_qRelu/out/ref_qRelu_0.idx"), "ref_out");
     S_TENSOR ref_min =
-        ctx.add(t_import.float_import("/fs/testData/ref_qRelu/out/ref_qRelu_1.idx", "ref_min"));
+        ctx.add(t_import.float_import("/fs/testData/ref_qRelu/out/ref_qRelu_1.idx"), "ref_min");
     S_TENSOR ref_max =
-        ctx.add(t_import.float_import("/fs/testData/ref_qRelu/out/ref_qRelu_2.idx", "ref_max"));
+        ctx.add(t_import.float_import("/fs/testData/ref_qRelu/out/ref_qRelu_2.idx"), "ref_max");
 
     // modify the checks below:
-    S_TENSOR out = ctx.add(new RamTensor<unsigned char>(ref_out->getShape(), "out"));
-    S_TENSOR out_min = ctx.add(new RamTensor<float>(ref_min->getShape(), "out_min"));
-    S_TENSOR out_max = ctx.add(new RamTensor<float>(ref_max->getShape(), "out_max"));
+    S_TENSOR out = ctx.add(new RamTensor<unsigned char>(ref_out->getShape()), "out");
+    S_TENSOR out_min = ctx.add(new RamTensor<float>(ref_min->getShape()), "out_min");
+    S_TENSOR out_max = ctx.add(new RamTensor<float>(ref_max->getShape()), "out_max");
 
 
     timer_start();

--- a/context.cpp
+++ b/context.cpp
@@ -1,14 +1,40 @@
 #include "context.hpp"
 
-S_TENSOR Context::add(std::function<void*(void)> func, uint8_t init_count) {
-  Tensor* t = (Tensor*) func();
+S_TENSOR Context::add_static(std::function<void*(void)> func, TName _name) {
+  return addCached(func, _name, 1, true);
+}
+
+S_TENSOR Context::addCached(std::function<void*(void)> func, TName _name, uint8_t init_count, bool _is_static) {
+  Tensor* t;
+  if(rTable.find(_name) == rTable.end()) {
+    t = (Tensor*) func();
+    add(t, _name);
+  }
+
+  Ref_Record record = rTable[_name];
+  record.is_static = _is_static;
+  record.is_cacheable = true;
+  if(init_count > 0) {
+    record.count = init_count;
+    record.allow_incr = false;
+  }
+  if(record.count < 1 && record.is_static) {
+    record.count = 1;
+  }
+  rTable[_name] = record;
+
+  return record.sptr;
+}
+
+S_TENSOR Context::add(Tensor* t, TName _name, uint8_t init_count) {
   if(t == nullptr) { ERR_EXIT("null pointer tensor"); }
-  if(rTable.find(t->getName()) != rTable.end()) {
+  if(rTable.find(_name) != rTable.end()) {
     ///NT: TODO: check stateful here
     ERR_EXIT("tensor with name \"%s\" address already exist in rTable", t->getName().c_str());
   }
 
   S_TENSOR _sptr(t);
+  t->setName(_name);
 
   Ref_Record record;
 
@@ -19,7 +45,7 @@ S_TENSOR Context::add(std::function<void*(void)> func, uint8_t init_count) {
 
   record.sptr = _sptr;
 
-  rTable[t->getName()] = record;
+  rTable[_name] = record;
 
   return _sptr;
 }
@@ -29,9 +55,42 @@ S_TENSOR Context::get(TName const &t_name) {
   return rTable[t_name].sptr;
 }
 
+Operator* Context::registerOpTable(std::function<void*(void)> func, TName _name) {
+  Operator* op;
+  //empty static op tensor list
+  if(opTable.find(_name) == opTable.end()) {
+    op = (Operator*) func();
+    op->setName(_name);
+  } else {
+    op = opTable[_name];
+  }
+  
+  return op;
+}
 
-void Context::push(std::function<void*(void)> func, TNameList &in_names, TNameList &out_names) {
-  Operator* op = (Operator*) func();
+void Context::push_static(std::function<void*(void)> func, TName _name, TNameList &_inputs, TNameList &_outputs, bool is_static) {
+  push(registerOpTable(func, _name), _inputs, _outputs);
+}
+void Context::push_static(std::function<void*(void)> func, TName _name, std::initializer_list<TName> _inputs, std::initializer_list<TName> _outputs, bool is_static) {
+  push(registerOpTable(func, _name), _inputs, _outputs);
+}
+
+void Context::push(Operator* op, std::initializer_list<TName> _inputs, std::initializer_list<TName> _outputs) {
+  TNameList inputs;
+  TNameList outputs;
+
+  for(auto i:_inputs) {
+    inputs.push_back(i);
+  }
+
+  for(auto o:_outputs) {
+    outputs.push_back(o);
+  }
+
+  push(op, inputs, outputs);
+}
+
+void Context::push(Operator* op, TNameList &in_names, TNameList &out_names) {
   //error checking in the Op class
   S_TList _inputs;
   for(auto in:in_names) {
@@ -54,21 +113,6 @@ void Context::push(std::function<void*(void)> func, TNameList &in_names, TNameLi
 
 }
 
-void Context::push(std::function<void*(void)> func, std::initializer_list<TName> _inputs, std::initializer_list<TName> _outputs) {
-  TNameList inputs;
-  TNameList outputs;
-
-  for(auto i:_inputs) {
-    inputs.push_back(i);
-  }
-
-  for(auto o:_outputs) {
-    outputs.push_back(o);
-  }
-
-  push(func, inputs, outputs);
-}
-
 void Context::incrTNameListRef(const TNameList &t_list) {
   for(auto t_name:t_list) {
     if(rTable.find(t_name) == rTable.end()) {
@@ -76,7 +120,7 @@ void Context::incrTNameListRef(const TNameList &t_list) {
     }
 
     Ref_Record record = rTable[t_name];
-    if(record.allow_incr) {
+    if(record.allow_incr && !record.is_static) {
       record.count++;
       rTable[t_name] = record;
     }
@@ -120,7 +164,7 @@ uint8_t Context::dcrRef(TName t_name) {
   }
 
   Ref_Record record = rTable[t_name];
-  if(record.count > 0) record.count -= 1;
+  if(record.count > 0 && !record.is_static) record.count -= 1;
   rTable[t_name] = record;
 
   return record.count;
@@ -128,6 +172,14 @@ uint8_t Context::dcrRef(TName t_name) {
 
 bool Context::isTracked(TName t_name) {
   return (rTable.find(t_name) != rTable.end());
+}
+
+void Context::cleanUpOp(Operator* op) {
+  if(opTable.find(op->getName()) == opTable.end()) {
+    delete op;
+  } else {
+    op->empty();
+  }
 }
 
 int Context::eval(void) {
@@ -146,11 +198,8 @@ int Context::eval(void) {
 
     dcrListRef(op->getInputs());
 
-    delete op;  ///NT: TODO: replace this with a cleanupOp(op) method
-                ///context would require a new op record table
-                ///addStateful(Ops, name)
-                ///push(opName, ...)
-                ///Can you pass constructor as a reference?
+
+    cleanUpOp(op);
 
   }
 

--- a/context.cpp
+++ b/context.cpp
@@ -1,6 +1,7 @@
 #include "context.hpp"
 
-S_TENSOR Context::add(Tensor* t, uint8_t init_count) {
+S_TENSOR Context::add(std::function<void*(void)> func, uint8_t init_count) {
+  Tensor* t = (Tensor*) func();
   if(t == nullptr) { ERR_EXIT("null pointer tensor"); }
   if(rTable.find(t->getName()) != rTable.end()) {
     ///NT: TODO: check stateful here
@@ -29,7 +30,8 @@ S_TENSOR Context::get(TName const &t_name) {
 }
 
 
-void Context::push(Operator *op, TNameList &in_names, TNameList &out_names) {
+void Context::push(std::function<void*(void)> func, TNameList &in_names, TNameList &out_names) {
+  Operator* op = (Operator*) func();
   //error checking in the Op class
   S_TList _inputs;
   for(auto in:in_names) {
@@ -52,7 +54,7 @@ void Context::push(Operator *op, TNameList &in_names, TNameList &out_names) {
 
 }
 
-void Context::push(Operator *op, std::initializer_list<TName> _inputs, std::initializer_list<TName> _outputs) {
+void Context::push(std::function<void*(void)> func, std::initializer_list<TName> _inputs, std::initializer_list<TName> _outputs) {
   TNameList inputs;
   TNameList outputs;
 
@@ -64,7 +66,7 @@ void Context::push(Operator *op, std::initializer_list<TName> _inputs, std::init
     outputs.push_back(o);
   }
 
-  push(op, inputs, outputs);
+  push(func, inputs, outputs);
 }
 
 void Context::incrTNameListRef(const TNameList &t_list) {

--- a/context.cpp
+++ b/context.cpp
@@ -3,6 +3,7 @@
 S_TENSOR Context::add(Tensor* t, uint8_t init_count) {
   if(t == nullptr) { ERR_EXIT("null pointer tensor"); }
   if(rTable.find(t->getName()) != rTable.end()) {
+    ///NT: TODO: check stateful here
     ERR_EXIT("tensor with name \"%s\" address already exist in rTable", t->getName().c_str());
   }
 
@@ -143,7 +144,11 @@ int Context::eval(void) {
 
     dcrListRef(op->getInputs());
 
-    delete op;
+    delete op;  ///NT: TODO: replace this with a cleanupOp(op) method
+                ///context would require a new op record table
+                ///addStateful(Ops, name)
+                ///push(opName, ...)
+                ///Can you pass constructor as a reference?
 
   }
 

--- a/context.cpp
+++ b/context.cpp
@@ -29,7 +29,6 @@ S_TENSOR Context::addCached(std::function<void*(void)> func, TName _name, uint8_
 S_TENSOR Context::add(Tensor* t, TName _name, uint8_t init_count) {
   if(t == nullptr) { ERR_EXIT("null pointer tensor"); }
   if(rTable.find(_name) != rTable.end()) {
-    ///NT: TODO: check stateful here
     ERR_EXIT("tensor with name \"%s\" address already exist in rTable", t->getName().c_str());
   }
 
@@ -210,6 +209,7 @@ int Context::eval(void) {
 
 uint32_t Context::gc(void) {
   TNameList nlist;
+  ///NT: TODO: implement cache policy here
 
   for ( auto it : rTable) {
     Ref_Record r = it.second;

--- a/context.hpp
+++ b/context.hpp
@@ -13,10 +13,14 @@ class Ref_Record {
 public:
   uint8_t count;
   bool allow_incr;
+  bool is_static;
+  bool is_cacheable;
   S_TENSOR sptr;
 
   Ref_Record() {
     count = 0;
+    is_static = false;
+    is_cacheable = true;
     allow_incr = true;
     sptr.reset();   
   }
@@ -27,7 +31,8 @@ protected:
   std::vector<Operator*> op_list;
   bool del_onsight;
 
-  std::unordered_map<TName, Ref_Record> rTable;  //all tensors alive  //kill all unused if malloc failed?
+  std::unordered_map<TName, Ref_Record> rTable;
+  std::unordered_map<TName, Operator*> opTable;  //all tensors alive  //kill all unused if malloc failed?
   //uint32_t m_size; //remaining memory size
   //void registerTensor(Tensor* t);
   //void gc(void); //garbage collector, delete any tracked unreferenced tensor
@@ -41,15 +46,20 @@ protected:
   //uint16_t incrRef(std::shared_ptr<Tensor> sptr);
   uint8_t dcrRef(TName name);
   bool isTracked(TName name);
+  void cleanUpOp(Operator* op);
+  Operator* registerOpTable(std::function<void*(void)> func, TName _name);
   //bool isTracked(Tensor* t);
   //uint16_t getRef();
 
 public:
-//S_TENSOR addStateful(std::function<void*(void)> func);
-  S_TENSOR add(std::function<void*(void)> func, uint8_t init_count = 0);
+  S_TENSOR add_static(std::function<void*(void)> func, TName _name);
+  S_TENSOR addCached(std::function<void*(void)> func, TName _name, uint8_t init_count = 0, bool _is_static = false);
+  S_TENSOR add(Tensor* t, TName _name, uint8_t init_count = 0);
   S_TENSOR get(TName const &t_name);
-  void push(std::function<void*(void)> func, TNameList &_inputs, TNameList &_outputs);
-  void push(std::function<void*(void)> func, std::initializer_list<TName> _inputs, std::initializer_list<TName> _outputs);
+  void push_static(std::function<void*(void)> func, TName _name, TNameList &_inputs, TNameList &_outputs, bool is_static = false);
+  void push_static(std::function<void*(void)> func, TName _name, std::initializer_list<TName> _inputs, std::initializer_list<TName> _outputs, bool is_static = false);
+  void push(Operator* op, TNameList &_inputs, TNameList &_outputs);
+  void push(Operator* op, std::initializer_list<TName> _inputs, std::initializer_list<TName> _outputs);
   uint32_t gc(void);
   int eval(void);
 
@@ -59,6 +69,6 @@ public:
 };
 
 
-#define defer(...) ([&](){return (void*) (__VA_ARGS__);})
+#define hold(...) ([&](){return (void*) (__VA_ARGS__);})
 
 #endif // UTENSOR_CTX_H

--- a/context.hpp
+++ b/context.hpp
@@ -6,6 +6,7 @@
 #include <initializer_list>
 #include "uTensorBase.hpp"
 #include "stdio.h"
+#include <functional>
 //#include <list>
 
 class Ref_Record {
@@ -44,10 +45,11 @@ protected:
   //uint16_t getRef();
 
 public:
-  S_TENSOR add(Tensor* t, uint8_t init_count = 0);
+//S_TENSOR addStateful(std::function<void*(void)> func);
+  S_TENSOR add(std::function<void*(void)> func, uint8_t init_count = 0);
   S_TENSOR get(TName const &t_name);
-  void push(Operator *op, TNameList &_inputs, TNameList &_outputs);
-  void push(Operator *op, std::initializer_list<TName> _inputs, std::initializer_list<TName> _outputs);
+  void push(std::function<void*(void)> func, TNameList &_inputs, TNameList &_outputs);
+  void push(std::function<void*(void)> func, std::initializer_list<TName> _inputs, std::initializer_list<TName> _outputs);
   uint32_t gc(void);
   int eval(void);
 
@@ -57,5 +59,6 @@ public:
 };
 
 
+#define defer(...) ([&](){return (void*) (__VA_ARGS__);})
 
 #endif // UTENSOR_CTX_H

--- a/context_test.hpp
+++ b/context_test.hpp
@@ -17,6 +17,16 @@ class contextTest : public Test {
   TensorIdxImporter t_import;
   Context ctx;
 
+private:
+
+  TName codeGenStatfulHelper(TName input) {
+    ctx.add(TensorConstant({1}, 1, "incr_val"));
+    ctx.add(new RamTensor<float>(ref_out->getShape(), "out"));  //gc problem?
+    ctx.push(new AddOp<uint32_t, uint32_t>(), {"incr_val", input}, output);
+
+    return output;
+  }
+
 public:
   void RefCountTest(void) {
     testStart("Context Ref Count");
@@ -61,10 +71,14 @@ public:
 
   }
 
+  void codeGenTemplate(void) {
+    ctx.gc();
+  }
+
 
   void runAll(void) {
-    // MatMalTest();
     RefCountTest();
+    codeGenTemplate();
   }
 };
 

--- a/context_test.hpp
+++ b/context_test.hpp
@@ -20,9 +20,9 @@ class contextTest : public Test {
 private:
 
   void codeGenStatfulHelper(TName state) {
-    ctx.add(defer(TensorConstant<uint32_t>({1}, 1, "incr_val")));
-    ctx.add(defer(new RamTensor<uint32_t>({1}, "out")));  //gc problem?
-    ctx.push(defer(new AddOp<uint32_t, uint32_t>()), {"incr_val", state}, {"out"});
+    ctx.add(TensorConstant<uint32_t>({1}, 1), "incr_val");
+    ctx.add(new RamTensor<uint32_t>({1}), "out");  //gc problem?
+    ctx.push(new AddOp<uint32_t, uint32_t>(), {"incr_val", state}, {"out"});
     ctx.eval();
   }
 
@@ -35,9 +35,9 @@ public:
     timer_start();
     //inputs
     
-    S_TENSOR a = ctx.add(defer(new RamTensor<int>({1,1,1}, "a")));
-    S_TENSOR b = ctx.add(defer(new RamTensor<int>({1,1,1}, "b")));
-    S_TENSOR c = ctx.add(defer(new RamTensor<int>({1,1,1}, "c")));
+    S_TENSOR a = ctx.add(new RamTensor<int>({1,1,1}), "a");
+    S_TENSOR b = ctx.add(new RamTensor<int>({1,1,1}), "b");
+    S_TENSOR c = ctx.add(new RamTensor<int>({1,1,1}), "c");
 
     //init values
     *(a->write<int>(0, 0)) = 1;
@@ -45,19 +45,19 @@ public:
     *(c->write<int>(0, 0)) = 1;
 
     // reference outputs
-    S_TENSOR out = ctx.add(defer(new RamTensor<int>({1,1,1}, "out")));
+    S_TENSOR out = ctx.add(new RamTensor<int>({1,1,1}), "out");
 
     TNameList inputs0 = {"a", "b"};
     TNameList outputs0 = {"c"};  //2
-    ctx.push(defer(new AddOp<int, int>()), inputs0, outputs0);
+    ctx.push(new AddOp<int, int>(), inputs0, outputs0);
 
     TNameList inputs1 = {"c", "a"};
     TNameList outputs1 = {"b"};  //3
-    ctx.push(defer(new AddOp<int, int>()), inputs1, outputs1);
+    ctx.push(new AddOp<int, int>(), inputs1, outputs1);
 
     TNameList inputs2 = {"a", "b"};
     TNameList outputs2 = {"out"};  //4
-    ctx.push(defer(new AddOp<int, int>()), inputs2, outputs2);
+    ctx.push(new AddOp<int, int>(), inputs2, outputs2);
     ctx.eval();
     timer_stop();
 
@@ -74,9 +74,9 @@ public:
   void codeGenTemplate(void) {
     testStart("codeGenTemplate");
     ctx.gc();
-    S_TENSOR state = ctx.add(defer(TensorConstant<uint32_t>({1}, 0, "state")), 255);
     S_TENSOR out;
     for(auto i = 0; i < 5; i++) {
+      S_TENSOR state = ctx.add_static(hold(TensorConstant<uint32_t>({1}, 0)), "state");
       codeGenStatfulHelper("state");
       out = ctx.get("out");
       *(state->write<uint32_t>(0, 0)) = *(out->read<uint32_t>(0, 0));

--- a/context_test.hpp
+++ b/context_test.hpp
@@ -20,9 +20,9 @@ class contextTest : public Test {
 private:
 
   void codeGenStatfulHelper(TName state) {
-    ctx.add(TensorConstant<uint32_t>({1}, 1, "incr_val"));
-    ctx.add(new RamTensor<uint32_t>({1}, "out"));  //gc problem?
-    ctx.push(new AddOp<uint32_t, uint32_t>(), {"incr_val", state}, {"out"});
+    ctx.add(defer(TensorConstant<uint32_t>({1}, 1, "incr_val")));
+    ctx.add(defer(new RamTensor<uint32_t>({1}, "out")));  //gc problem?
+    ctx.push(defer(new AddOp<uint32_t, uint32_t>()), {"incr_val", state}, {"out"});
     ctx.eval();
   }
 
@@ -34,9 +34,10 @@ public:
 
     timer_start();
     //inputs
-    S_TENSOR a = ctx.add(new RamTensor<int>({1,1,1}, "a"));
-    S_TENSOR b = ctx.add(new RamTensor<int>({1,1,1}, "b"));
-    S_TENSOR c = ctx.add(new RamTensor<int>({1,1,1}, "c"));
+    
+    S_TENSOR a = ctx.add(defer(new RamTensor<int>({1,1,1}, "a")));
+    S_TENSOR b = ctx.add(defer(new RamTensor<int>({1,1,1}, "b")));
+    S_TENSOR c = ctx.add(defer(new RamTensor<int>({1,1,1}, "c")));
 
     //init values
     *(a->write<int>(0, 0)) = 1;
@@ -44,19 +45,19 @@ public:
     *(c->write<int>(0, 0)) = 1;
 
     // reference outputs
-    S_TENSOR out = ctx.add(new RamTensor<int>({1,1,1}, "out"));
+    S_TENSOR out = ctx.add(defer(new RamTensor<int>({1,1,1}, "out")));
 
     TNameList inputs0 = {"a", "b"};
     TNameList outputs0 = {"c"};  //2
-    ctx.push(new AddOp<int, int>(), inputs0, outputs0);
+    ctx.push(defer(new AddOp<int, int>()), inputs0, outputs0);
 
     TNameList inputs1 = {"c", "a"};
     TNameList outputs1 = {"b"};  //3
-    ctx.push(new AddOp<int, int>(), inputs1, outputs1);
+    ctx.push(defer(new AddOp<int, int>()), inputs1, outputs1);
 
     TNameList inputs2 = {"a", "b"};
     TNameList outputs2 = {"out"};  //4
-    ctx.push(new AddOp<int, int>(), inputs2, outputs2);
+    ctx.push(defer(new AddOp<int, int>()), inputs2, outputs2);
     ctx.eval();
     timer_stop();
 
@@ -73,7 +74,7 @@ public:
   void codeGenTemplate(void) {
     testStart("codeGenTemplate");
     ctx.gc();
-    S_TENSOR state = ctx.add(TensorConstant<uint32_t>({1}, 0, "state"), 255);
+    S_TENSOR state = ctx.add(defer(TensorConstant<uint32_t>({1}, 0, "state")), 255);
     S_TENSOR out;
     for(auto i = 0; i < 5; i++) {
       codeGenStatfulHelper("state");

--- a/deep_mnist_mlp.cpp
+++ b/deep_mnist_mlp.cpp
@@ -1,191 +1,191 @@
-#include "deep_mnist_mlp.hpp"
+// #include "deep_mnist_mlp.hpp"
 
-void tensorQuantize(Context& ctx, TName input, TName output,
-  TName out_min, TName out_max) {
+// void tensorQuantize(Context& ctx, TName input, TName output,
+//   TName out_min, TName out_max) {
 
-    //reshape
-    S_TENSOR reduce_dim = ctx.add(new RamTensor<int>({1}, "reduce_dim"));
-    S_TENSOR reshape_out = ctx.add(new RamTensor<float>("reshape_out"));
+//     //reshape
+//     S_TENSOR reduce_dim = ctx.add(new RamTensor<int>({1}, "reduce_dim"));
+//     S_TENSOR reshape_out = ctx.add(new RamTensor<float>("reshape_out"));
 
-    S_TENSOR reshape_shape = ctx.add(new RamTensor<int>("reshape_shape"));
+//     S_TENSOR reshape_shape = ctx.add(new RamTensor<int>("reshape_shape"));
 
-    *(reduce_dim->write<int>(0, 0)) = 0;
-    ctx.push(new ReshapeOp(), {input, "reshape_shape"}, {"reshape_out"});
+//     *(reduce_dim->write<int>(0, 0)) = 0;
+//     ctx.push(new ReshapeOp(), {input, "reshape_shape"}, {"reshape_out"});
 
 
-    //Min and Max of (reshaped) input
-    S_TENSOR min_out = ctx.add(new RamTensor<float>({1}, "min_out"));
-    S_TENSOR max_out = ctx.add(new RamTensor<float>({1}, "max_out"));
-    ctx.push(new MinOp(), {"reshape_out", "reduce_dim"}, {"min_out"});
-    ctx.push(new MaxOp(), {"reshape_out", "reduce_dim"}, {"max_out"});
+//     //Min and Max of (reshaped) input
+//     S_TENSOR min_out = ctx.add(new RamTensor<float>({1}, "min_out"));
+//     S_TENSOR max_out = ctx.add(new RamTensor<float>({1}, "max_out"));
+//     ctx.push(new MinOp(), {"reshape_out", "reduce_dim"}, {"min_out"});
+//     ctx.push(new MaxOp(), {"reshape_out", "reduce_dim"}, {"max_out"});
 
-    ctx.push(new QuantizeV2Op(), {"reshape_out", "min_out", "max_out"}, {output, out_min, out_max});
-}
+//     ctx.push(new QuantizeV2Op(), {"reshape_out", "min_out", "max_out"}, {output, out_min, out_max});
+// }
 
-void ReluLayer(Context& ctx, TName x, TName x_min, TName x_max,
-   TName w, TName w_min, TName w_max, TName b,
-    TName z_output) {
+// void ReluLayer(Context& ctx, TName x, TName x_min, TName x_max,
+//    TName w, TName w_min, TName w_max, TName b,
+//     TName z_output) {
   
-    //quantized matmul
+//     //quantized matmul
 
-    S_TENSOR out_c = ctx.add(new RamTensor<int>("out_c"));
+//     S_TENSOR out_c = ctx.add(new RamTensor<int>("out_c"));
 
-    S_TENSOR matmul_out_min = ctx.add(new RamTensor<float>({1}, "matmul_out_min"));
-    S_TENSOR matmul_out_max = ctx.add(new RamTensor<float>({1}, "matmul_out_max"));
+//     S_TENSOR matmul_out_min = ctx.add(new RamTensor<float>({1}, "matmul_out_min"));
+//     S_TENSOR matmul_out_max = ctx.add(new RamTensor<float>({1}, "matmul_out_max"));
 
-    ctx.push(new QntMatMulOp<uint8_t, uint8_t, int>(), {x, x_min, x_max, w, w_min, w_max}, {"out_c", "matmul_out_min", "matmul_out_max"});
+//     ctx.push(new QntMatMulOp<uint8_t, uint8_t, int>(), {x, x_min, x_max, w, w_min, w_max}, {"out_c", "matmul_out_min", "matmul_out_max"});
 
-    //Requantization_Range
-    S_TENSOR req_out_min = ctx.add(new RamTensor<float>({1}, "req_out_min"));
-    S_TENSOR req_out_max = ctx.add(new RamTensor<float>({1}, "req_out_max"));
-    ctx.push(new Requantization_RangeOp(), {"out_c", "matmul_out_min", "matmul_out_max"}, {"req_out_min", "req_out_max"});
+//     //Requantization_Range
+//     S_TENSOR req_out_min = ctx.add(new RamTensor<float>({1}, "req_out_min"));
+//     S_TENSOR req_out_max = ctx.add(new RamTensor<float>({1}, "req_out_max"));
+//     ctx.push(new Requantization_RangeOp(), {"out_c", "matmul_out_min", "matmul_out_max"}, {"req_out_min", "req_out_max"});
 
-    //Requantize
-    S_TENSOR reqnt_out = ctx.add(new RamTensor<unsigned char>("reqnt_out"));
-    S_TENSOR reqnt_out_min = ctx.add(new RamTensor<float>({1}, "reqnt_out_min"));
-    S_TENSOR reqnt_out_max = ctx.add(new RamTensor<float>({1}, "reqnt_out_max"));
-    ctx.push(new RequantizeOp(), {"out_c", "matmul_out_min", "matmul_out_max", "req_out_min", "req_out_max"}, {"reqnt_out", "reqnt_out_min", "reqnt_out_max"});
+//     //Requantize
+//     S_TENSOR reqnt_out = ctx.add(new RamTensor<unsigned char>("reqnt_out"));
+//     S_TENSOR reqnt_out_min = ctx.add(new RamTensor<float>({1}, "reqnt_out_min"));
+//     S_TENSOR reqnt_out_max = ctx.add(new RamTensor<float>({1}, "reqnt_out_max"));
+//     ctx.push(new RequantizeOp(), {"out_c", "matmul_out_min", "matmul_out_max", "req_out_min", "req_out_max"}, {"reqnt_out", "reqnt_out_min", "reqnt_out_max"});
 
-    Shape out_shape = out_c->getShape();
-    //clean up
+//     Shape out_shape = out_c->getShape();
+//     //clean up
 
-    S_TENSOR deqnt_out = ctx.add(new RamTensor<float>("deqnt_out"));
-    ctx.push(new DequantizeOp(), {"reqnt_out", "reqnt_out_min", "reqnt_out_max"}, {"deqnt_out"});
+//     S_TENSOR deqnt_out = ctx.add(new RamTensor<float>("deqnt_out"));
+//     ctx.push(new DequantizeOp(), {"reqnt_out", "reqnt_out_min", "reqnt_out_max"}, {"deqnt_out"});
 
-    ctx.push(new AddOp<float, float>(), {"deqnt_out", b}, {z_output});
+//     ctx.push(new AddOp<float, float>(), {"deqnt_out", b}, {z_output});
 
-}
+// }
 
-void PredLayer(Context &ctx, TName input, TName input_min,
-               TName input_max, TName output, TName w, TName w_min, TName w_max, TName bias, TName dim) {
+// void PredLayer(Context &ctx, TName input, TName input_min,
+//                TName input_max, TName output, TName w, TName w_min, TName w_max, TName bias, TName dim) {
 
-  S_TENSOR out_mat_pred = ctx.add(new RamTensor<int>("out_mat_pred"));
-  S_TENSOR matmul_out_min_pred = ctx.add(new RamTensor<float>({1}, "matmul_out_min_pred"));
-  S_TENSOR matmul_out_max_pred = ctx.add(new RamTensor<float>({1}, "matmul_out_max_pred"));
+//   S_TENSOR out_mat_pred = ctx.add(new RamTensor<int>("out_mat_pred"));
+//   S_TENSOR matmul_out_min_pred = ctx.add(new RamTensor<float>({1}, "matmul_out_min_pred"));
+//   S_TENSOR matmul_out_max_pred = ctx.add(new RamTensor<float>({1}, "matmul_out_max_pred"));
 
-  //MatMul
-  ctx.push(new QntMatMulOp<uint8_t, uint8_t, int>(), {input, input_min, input_max, w, w_min, w_max},
-          {"out_mat_pred", "matmul_out_min_pred", "matmul_out_max_pred"});
+//   //MatMul
+//   ctx.push(new QntMatMulOp<uint8_t, uint8_t, int>(), {input, input_min, input_max, w, w_min, w_max},
+//           {"out_mat_pred", "matmul_out_min_pred", "matmul_out_max_pred"});
 
-  //Requantization_Range
-  S_TENSOR req_out_min = ctx.add(new RamTensor<float>({1}, "req_out_min_pred"));
-  S_TENSOR req_out_max = ctx.add(new RamTensor<float>({1}, "req_out_max_pred"));
-  ctx.push(new Requantization_RangeOp(), {"out_mat_pred", "matmul_out_min_pred", "matmul_out_max_pred"},
-          {"req_out_min_pred", "req_out_max_pred"});
+//   //Requantization_Range
+//   S_TENSOR req_out_min = ctx.add(new RamTensor<float>({1}, "req_out_min_pred"));
+//   S_TENSOR req_out_max = ctx.add(new RamTensor<float>({1}, "req_out_max_pred"));
+//   ctx.push(new Requantization_RangeOp(), {"out_mat_pred", "matmul_out_min_pred", "matmul_out_max_pred"},
+//           {"req_out_min_pred", "req_out_max_pred"});
 
-  //Requantize
-  S_TENSOR reqnt_out = ctx.add(new RamTensor<unsigned char>("reqnt_out_pred"));
-  S_TENSOR reqnt_out_min = ctx.add(new RamTensor<float>({1}, "reqnt_out_min_pred"));
-  S_TENSOR reqnt_out_max = ctx.add(new RamTensor<float>({1}, "reqnt_out_max_pred"));
-  ctx.push(new RequantizeOp(), {"out_mat_pred", "matmul_out_min_pred", "matmul_out_max_pred", "req_out_min_pred", "req_out_max_pred"},
-          {"reqnt_out_pred", "reqnt_out_min_pred", "reqnt_out_max_pred"});
+//   //Requantize
+//   S_TENSOR reqnt_out = ctx.add(new RamTensor<unsigned char>("reqnt_out_pred"));
+//   S_TENSOR reqnt_out_min = ctx.add(new RamTensor<float>({1}, "reqnt_out_min_pred"));
+//   S_TENSOR reqnt_out_max = ctx.add(new RamTensor<float>({1}, "reqnt_out_max_pred"));
+//   ctx.push(new RequantizeOp(), {"out_mat_pred", "matmul_out_min_pred", "matmul_out_max_pred", "req_out_min_pred", "req_out_max_pred"},
+//           {"reqnt_out_pred", "reqnt_out_min_pred", "reqnt_out_max_pred"});
 
-  //dequantize
-  S_TENSOR deqnt_out = ctx.add(new RamTensor<float>("deqnt_out_pred"));
-  ctx.push(new DequantizeOp(), {"reqnt_out_pred", "reqnt_out_min_pred", "reqnt_out_max_pred"}, {"deqnt_out_pred"});
+//   //dequantize
+//   S_TENSOR deqnt_out = ctx.add(new RamTensor<float>("deqnt_out_pred"));
+//   ctx.push(new DequantizeOp(), {"reqnt_out_pred", "reqnt_out_min_pred", "reqnt_out_max_pred"}, {"deqnt_out_pred"});
 
-  //Add
-  S_TENSOR output_z = ctx.add(new RamTensor<float>("output_z_pred")); 
-  ctx.push(new AddOp<float, float>(), {"deqnt_out_pred", bias}, {"output_z_pred"});
+//   //Add
+//   S_TENSOR output_z = ctx.add(new RamTensor<float>("output_z_pred")); 
+//   ctx.push(new AddOp<float, float>(), {"deqnt_out_pred", bias}, {"output_z_pred"});
 
-  //ArgMax
-  ctx.push(new ArgMaxOp<float, int>(), {"output_z_pred", dim}, {output});
-}
+//   //ArgMax
+//   ctx.push(new ArgMaxOp<float, int>(), {"output_z_pred", dim}, {output});
+// }
 
-int runMLP(string inputIdxFile) {
-  TensorIdxImporter t_import;
-  Context ctx;
-  S_TENSOR x_quantized = ctx.add(new RamTensor<unsigned char>("x_quantized")); 
-  S_TENSOR x_min = ctx.add(new RamTensor<float>({1}, "x_min"));
-  S_TENSOR x_max = ctx.add(new RamTensor<float>({1}, "x_max")); 
-  S_TENSOR x = ctx.add(t_import.float_import(inputIdxFile, "x"));
+// int runMLP(string inputIdxFile) {
+//   TensorIdxImporter t_import;
+//   Context ctx;
+//   S_TENSOR x_quantized = ctx.add(new RamTensor<unsigned char>("x_quantized")); 
+//   S_TENSOR x_min = ctx.add(new RamTensor<float>({1}, "x_min"));
+//   S_TENSOR x_max = ctx.add(new RamTensor<float>({1}, "x_max")); 
+//   S_TENSOR x = ctx.add(t_import.float_import(inputIdxFile, "x"));
 
-  tensorQuantize(ctx, "x", "x_quantized", "x_min", "x_max");
-  ctx.eval();
+//   tensorQuantize(ctx, "x", "x_quantized", "x_min", "x_max");
+//   ctx.eval();
 
- //relu layer first
+//  //relu layer first
 
-  S_TENSOR w = ctx.add(t_import.ubyte_import(
-      "/fs/testData/deep_mlp/import-Variable_quint8_const_0.idx", "w"));
-  S_TENSOR w_min =
-      ctx.add(t_import.float_import("/fs/testData/deep_mlp/import-Variable_min_0.idx", "w_min"));
-  S_TENSOR w_max =
-      ctx.add(t_import.float_import("/fs/testData/deep_mlp/import-Variable_max_0.idx", "w_max"));
-  S_TENSOR b =
-      ctx.add(t_import.float_import("/fs/testData/deep_mlp/import-Variable_1_0.idx", "b"));
-  S_TENSOR relu_output = ctx.add(new RamTensor<unsigned char>("relu_output"));
-  S_TENSOR relu_min = ctx.add(new RamTensor<float>({1}, "relu_min"));
-  S_TENSOR relu_max = ctx.add(new RamTensor<float>({1}, "relu_max"));
-  S_TENSOR z_output = ctx.add(new RamTensor<float>("z_output")); 
+//   S_TENSOR w = ctx.add(t_import.ubyte_import(
+//       "/fs/testData/deep_mlp/import-Variable_quint8_const_0.idx", "w"));
+//   S_TENSOR w_min =
+//       ctx.add(t_import.float_import("/fs/testData/deep_mlp/import-Variable_min_0.idx", "w_min"));
+//   S_TENSOR w_max =
+//       ctx.add(t_import.float_import("/fs/testData/deep_mlp/import-Variable_max_0.idx", "w_max"));
+//   S_TENSOR b =
+//       ctx.add(t_import.float_import("/fs/testData/deep_mlp/import-Variable_1_0.idx", "b"));
+//   S_TENSOR relu_output = ctx.add(new RamTensor<unsigned char>("relu_output"));
+//   S_TENSOR relu_min = ctx.add(new RamTensor<float>({1}, "relu_min"));
+//   S_TENSOR relu_max = ctx.add(new RamTensor<float>({1}, "relu_max"));
+//   S_TENSOR z_output = ctx.add(new RamTensor<float>("z_output")); 
 
-  ReluLayer(ctx, "x_quantized", "x_min", "x_max", "w", "w_min", "w_max", "b", "z_output");
+//   ReluLayer(ctx, "x_quantized", "x_min", "x_max", "w", "w_min", "w_max", "b", "z_output");
 
-  S_TENSOR z_qnt_output = ctx.add(new RamTensor<unsigned char>("z_qnt_output"));
-  S_TENSOR z_min = ctx.add(new RamTensor<float>({1}, "z_min"));
-  S_TENSOR z_max = ctx.add(new RamTensor<float>({1}, "z_max"));
-  tensorQuantize(ctx, "z_output", "z_qnt_output", "z_min", "z_max");
+//   S_TENSOR z_qnt_output = ctx.add(new RamTensor<unsigned char>("z_qnt_output"));
+//   S_TENSOR z_min = ctx.add(new RamTensor<float>({1}, "z_min"));
+//   S_TENSOR z_max = ctx.add(new RamTensor<float>({1}, "z_max"));
+//   tensorQuantize(ctx, "z_output", "z_qnt_output", "z_min", "z_max");
 
-  ctx.push(new ReluOp<unsigned char, float, unsigned char>(), {"z_qnt_output", "z_min", "z_max"}, {"relu_output", "relu_min", "relu_max"});
+//   ctx.push(new ReluOp<unsigned char, float, unsigned char>(), {"z_qnt_output", "z_min", "z_max"}, {"relu_output", "relu_min", "relu_max"});
 
-  ctx.eval();
+//   ctx.eval();
 
-  //relu layer 2
-  S_TENSOR w2 = ctx.add(t_import.ubyte_import(
-      "/fs/testData/deep_mlp/import-Variable_2_quint8_const_0.idx", "w2"));
-  S_TENSOR w_min2 = ctx.add(t_import.float_import(
-     "/fs/testData/deep_mlp/import-Variable_2_min_0.idx", "w_min2"));
-  S_TENSOR w_max2 = ctx.add(t_import.float_import(
-      "/fs/testData/deep_mlp/import-Variable_2_max_0.idx", "w_max2"));
-  S_TENSOR b2 = ctx.add(t_import.float_import("/fs/testData/deep_mlp/import-Variable_3_0.idx", "b2"));
-  S_TENSOR relu_output2 = ctx.add(new RamTensor<unsigned char>("relu_output2"));
-  S_TENSOR relu_min2 = ctx.add(new RamTensor<float>({1}, "relu_min2"));
-  S_TENSOR relu_max2 = ctx.add(new RamTensor<float>({1}, "relu_max2"));
+//   //relu layer 2
+//   S_TENSOR w2 = ctx.add(t_import.ubyte_import(
+//       "/fs/testData/deep_mlp/import-Variable_2_quint8_const_0.idx", "w2"));
+//   S_TENSOR w_min2 = ctx.add(t_import.float_import(
+//      "/fs/testData/deep_mlp/import-Variable_2_min_0.idx", "w_min2"));
+//   S_TENSOR w_max2 = ctx.add(t_import.float_import(
+//       "/fs/testData/deep_mlp/import-Variable_2_max_0.idx", "w_max2"));
+//   S_TENSOR b2 = ctx.add(t_import.float_import("/fs/testData/deep_mlp/import-Variable_3_0.idx", "b2"));
+//   S_TENSOR relu_output2 = ctx.add(new RamTensor<unsigned char>("relu_output2"));
+//   S_TENSOR relu_min2 = ctx.add(new RamTensor<float>({1}, "relu_min2"));
+//   S_TENSOR relu_max2 = ctx.add(new RamTensor<float>({1}, "relu_max2"));
 
-  S_TENSOR z_output2 = ctx.add(new RamTensor<float>("z_output2")); 
-  ReluLayer(ctx, "relu_output", "relu_min", "relu_max", "w2", "w_min2", "w_max2", "b2", "z_output2");
-
-
-  S_TENSOR z_qnt_output2 = ctx.add(new RamTensor<unsigned char>("z_qnt_output2"));
-  S_TENSOR z_min2 = ctx.add(new RamTensor<float>({1}, "z_min2"));
-  S_TENSOR z_max2 = ctx.add(new RamTensor<float>({1}, "z_max2"));
-  tensorQuantize(ctx, "z_output2", "z_qnt_output2", "z_min2", "z_max2");
-
-  ctx.push(new ReluOp<unsigned char, float, unsigned char>(), {"z_qnt_output2", "z_min2", "z_max2"}, {"relu_output2", "relu_min2", "relu_max2"});
-
-  ctx.eval();
-
-  S_TENSOR w3 = ctx.add(t_import.ubyte_import(
-      "/fs/testData/deep_mlp/runPredLayer/MatMul_2_eightbit_quantized_mat_mul/"
-      "inputs/Variable_4_quint8_const_0.idx", "w3"));
-  S_TENSOR w2_min = ctx.add(t_import.float_import(
-      "/fs/testData/deep_mlp/runPredLayer/MatMul_2_eightbit_quantized_mat_mul/"
-      "inputs/Variable_4_min_0.idx", "w2_min"));
-  S_TENSOR w2_max = ctx.add(t_import.float_import(
-      "/fs/testData/deep_mlp/runPredLayer/MatMul_2_eightbit_quantized_mat_mul/"
-      "inputs/Variable_4_max_0.idx", "w2_max"));
-  S_TENSOR bias2 = ctx.add(t_import.float_import(
-      "/fs/testData/deep_mlp/runPredLayer/add_2/inputs/Variable_5_0.idx", "bias2"));
-  S_TENSOR dim = ctx.add(t_import.int_import(
-      "/fs/testData/deep_mlp/runPredLayer/y_pred/inputs/"
-      "y_pred-dimension_0.idx", "dim"));
-
-  S_TENSOR pred = ctx.add(new RamTensor<int>("pred"));
-  PredLayer(ctx, "relu_output2", "relu_min2", "relu_max2", "pred", "w3", "w2_min", "w2_max", "bias2", "dim");
-  ctx.eval();
+//   S_TENSOR z_output2 = ctx.add(new RamTensor<float>("z_output2")); 
+//   ReluLayer(ctx, "relu_output", "relu_min", "relu_max", "w2", "w_min2", "w_max2", "b2", "z_output2");
 
 
-  Tensor* ref_out = t_import.float_import(
-    "/fs/testData/deep_mlp/runPredLayer/y_pred/outputs/y_pred_0.idx", "ref_out");
-  Tensor* ref_pred = TensorCast<float, int>(ref_out, "ref_pred");
+//   S_TENSOR z_qnt_output2 = ctx.add(new RamTensor<unsigned char>("z_qnt_output2"));
+//   S_TENSOR z_min2 = ctx.add(new RamTensor<float>({1}, "z_min2"));
+//   S_TENSOR z_max2 = ctx.add(new RamTensor<float>({1}, "z_max2"));
+//   tensorQuantize(ctx, "z_output2", "z_qnt_output2", "z_min2", "z_max2");
 
-  double result = Test::meanPercentErr<int>(ref_pred, pred.get());
+//   ctx.push(new ReluOp<unsigned char, float, unsigned char>(), {"z_qnt_output2", "z_min2", "z_max2"}, {"relu_output2", "relu_min2", "relu_max2"});
+
+//   ctx.eval();
+
+//   S_TENSOR w3 = ctx.add(t_import.ubyte_import(
+//       "/fs/testData/deep_mlp/runPredLayer/MatMul_2_eightbit_quantized_mat_mul/"
+//       "inputs/Variable_4_quint8_const_0.idx", "w3"));
+//   S_TENSOR w2_min = ctx.add(t_import.float_import(
+//       "/fs/testData/deep_mlp/runPredLayer/MatMul_2_eightbit_quantized_mat_mul/"
+//       "inputs/Variable_4_min_0.idx", "w2_min"));
+//   S_TENSOR w2_max = ctx.add(t_import.float_import(
+//       "/fs/testData/deep_mlp/runPredLayer/MatMul_2_eightbit_quantized_mat_mul/"
+//       "inputs/Variable_4_max_0.idx", "w2_max"));
+//   S_TENSOR bias2 = ctx.add(t_import.float_import(
+//       "/fs/testData/deep_mlp/runPredLayer/add_2/inputs/Variable_5_0.idx", "bias2"));
+//   S_TENSOR dim = ctx.add(t_import.int_import(
+//       "/fs/testData/deep_mlp/runPredLayer/y_pred/inputs/"
+//       "y_pred-dimension_0.idx", "dim"));
+
+//   S_TENSOR pred = ctx.add(new RamTensor<int>("pred"));
+//   PredLayer(ctx, "relu_output2", "relu_min2", "relu_max2", "pred", "w3", "w2_min", "w2_max", "bias2", "dim");
+//   ctx.eval();
+
+
+//   Tensor* ref_out = t_import.float_import(
+//     "/fs/testData/deep_mlp/runPredLayer/y_pred/outputs/y_pred_0.idx", "ref_out");
+//   Tensor* ref_pred = TensorCast<float, int>(ref_out, "ref_pred");
+
+//   double result = Test::meanPercentErr<int>(ref_pred, pred.get());
   
-  if (result < 0.0001) {
-    printf("PASSED %.8f\r\n\r\n", result);
-  } else {
-    printf("FAILED %.8f\r\n\r\n", result);
-  }
+//   if (result < 0.0001) {
+//     printf("PASSED %.8f\r\n\r\n", result);
+//   } else {
+//     printf("FAILED %.8f\r\n\r\n", result);
+//   }
 
-  return *(pred->read<int>(0, 0));
-  // output layer
-}
+//   return *(pred->read<int>(0, 0));
+//   // output layer
+// }

--- a/deep_mnist_mlp.cpp
+++ b/deep_mnist_mlp.cpp
@@ -1,191 +1,188 @@
-// #include "deep_mnist_mlp.hpp"
+#include "deep_mnist_mlp.hpp"
 
-// void tensorQuantize(Context& ctx, TName input, TName output,
-//   TName out_min, TName out_max) {
+void tensorQuantize(Context& ctx, TName input, TName output,
+  TName out_min, TName out_max) {
 
-//     //reshape
-//     S_TENSOR reduce_dim = ctx.add(new RamTensor<int>({1}, "reduce_dim"));
-//     S_TENSOR reshape_out = ctx.add(new RamTensor<float>("reshape_out"));
+    //reshape
+    S_TENSOR reduce_dim = ctx.add(new RamTensor<int>({1}), "reduce_dim");
+    ctx.add(new RamTensor<float>(), "reshape_out");
 
-//     S_TENSOR reshape_shape = ctx.add(new RamTensor<int>("reshape_shape"));
+    ctx.add(new RamTensor<int>(), "reshape_shape");
 
-//     *(reduce_dim->write<int>(0, 0)) = 0;
-//     ctx.push(new ReshapeOp(), {input, "reshape_shape"}, {"reshape_out"});
+    *(reduce_dim->write<int>(0, 0)) = 0;
+    ctx.push(new ReshapeOp(), {input, "reshape_shape"}, {"reshape_out"});
 
 
-//     //Min and Max of (reshaped) input
-//     S_TENSOR min_out = ctx.add(new RamTensor<float>({1}, "min_out"));
-//     S_TENSOR max_out = ctx.add(new RamTensor<float>({1}, "max_out"));
-//     ctx.push(new MinOp(), {"reshape_out", "reduce_dim"}, {"min_out"});
-//     ctx.push(new MaxOp(), {"reshape_out", "reduce_dim"}, {"max_out"});
+    //Min and Max of (reshaped) input
+    ctx.add(new RamTensor<float>({1}), "min_out");
+    ctx.add(new RamTensor<float>({1}), "max_out");
+    ctx.push(new MinOp(), {"reshape_out", "reduce_dim"}, {"min_out"});
+    ctx.push(new MaxOp(), {"reshape_out", "reduce_dim"}, {"max_out"});
 
-//     ctx.push(new QuantizeV2Op(), {"reshape_out", "min_out", "max_out"}, {output, out_min, out_max});
-// }
+    ctx.push(new QuantizeV2Op(), {"reshape_out", "min_out", "max_out"}, {output, out_min, out_max});
+}
 
-// void ReluLayer(Context& ctx, TName x, TName x_min, TName x_max,
-//    TName w, TName w_min, TName w_max, TName b,
-//     TName z_output) {
+void ReluLayer(Context& ctx, TName x, TName x_min, TName x_max,
+   TName w, TName w_min, TName w_max, TName b,
+    TName z_output) {
   
-//     //quantized matmul
+    //quantized matmul
 
-//     S_TENSOR out_c = ctx.add(new RamTensor<int>("out_c"));
+    S_TENSOR out_c = ctx.add(new RamTensor<int>(), "out_c");
 
-//     S_TENSOR matmul_out_min = ctx.add(new RamTensor<float>({1}, "matmul_out_min"));
-//     S_TENSOR matmul_out_max = ctx.add(new RamTensor<float>({1}, "matmul_out_max"));
+    ctx.add(new RamTensor<float>({1}), "matmul_out_min");
+    ctx.add(new RamTensor<float>({1}), "matmul_out_max");
 
-//     ctx.push(new QntMatMulOp<uint8_t, uint8_t, int>(), {x, x_min, x_max, w, w_min, w_max}, {"out_c", "matmul_out_min", "matmul_out_max"});
+    ctx.push(new QntMatMulOp<uint8_t, uint8_t, int>(), {x, x_min, x_max, w, w_min, w_max}, {"out_c", "matmul_out_min", "matmul_out_max"});
 
-//     //Requantization_Range
-//     S_TENSOR req_out_min = ctx.add(new RamTensor<float>({1}, "req_out_min"));
-//     S_TENSOR req_out_max = ctx.add(new RamTensor<float>({1}, "req_out_max"));
-//     ctx.push(new Requantization_RangeOp(), {"out_c", "matmul_out_min", "matmul_out_max"}, {"req_out_min", "req_out_max"});
+    //Requantization_Range
+    S_TENSOR req_out_min = ctx.add(new RamTensor<float>({1}), "req_out_min");
+    S_TENSOR req_out_max = ctx.add(new RamTensor<float>({1}), "req_out_max");
+    ctx.push(new Requantization_RangeOp(), {"out_c", "matmul_out_min", "matmul_out_max"}, {"req_out_min", "req_out_max"});
 
-//     //Requantize
-//     S_TENSOR reqnt_out = ctx.add(new RamTensor<unsigned char>("reqnt_out"));
-//     S_TENSOR reqnt_out_min = ctx.add(new RamTensor<float>({1}, "reqnt_out_min"));
-//     S_TENSOR reqnt_out_max = ctx.add(new RamTensor<float>({1}, "reqnt_out_max"));
-//     ctx.push(new RequantizeOp(), {"out_c", "matmul_out_min", "matmul_out_max", "req_out_min", "req_out_max"}, {"reqnt_out", "reqnt_out_min", "reqnt_out_max"});
+    //Requantize
+    ctx.add(new RamTensor<unsigned char>(), "reqnt_out");
+    ctx.add(new RamTensor<float>({1}), "reqnt_out_min");
+    ctx.add(new RamTensor<float>({1}), "reqnt_out_max");
+    ctx.push(new RequantizeOp(), {"out_c", "matmul_out_min", "matmul_out_max", "req_out_min", "req_out_max"}, {"reqnt_out", "reqnt_out_min", "reqnt_out_max"});
 
-//     Shape out_shape = out_c->getShape();
-//     //clean up
+    Shape out_shape = out_c->getShape();
+    //clean up
 
-//     S_TENSOR deqnt_out = ctx.add(new RamTensor<float>("deqnt_out"));
-//     ctx.push(new DequantizeOp(), {"reqnt_out", "reqnt_out_min", "reqnt_out_max"}, {"deqnt_out"});
+    S_TENSOR deqnt_out = ctx.add(new RamTensor<float>(), "deqnt_out");
+    ctx.push(new DequantizeOp(), {"reqnt_out", "reqnt_out_min", "reqnt_out_max"}, {"deqnt_out"});
 
-//     ctx.push(new AddOp<float, float>(), {"deqnt_out", b}, {z_output});
+    ctx.push(new AddOp<float, float>(), {"deqnt_out", b}, {z_output});
 
-// }
+}
 
-// void PredLayer(Context &ctx, TName input, TName input_min,
-//                TName input_max, TName output, TName w, TName w_min, TName w_max, TName bias, TName dim) {
+void PredLayer(Context &ctx, TName input, TName input_min,
+               TName input_max, TName output, TName w, TName w_min, TName w_max, TName bias, TName dim) {
 
-//   S_TENSOR out_mat_pred = ctx.add(new RamTensor<int>("out_mat_pred"));
-//   S_TENSOR matmul_out_min_pred = ctx.add(new RamTensor<float>({1}, "matmul_out_min_pred"));
-//   S_TENSOR matmul_out_max_pred = ctx.add(new RamTensor<float>({1}, "matmul_out_max_pred"));
+  S_TENSOR out_mat_pred = ctx.add(new RamTensor<int>(), "out_mat_pred");
+  S_TENSOR matmul_out_min_pred = ctx.add(new RamTensor<float>({1}), "matmul_out_min_pred");
+  S_TENSOR matmul_out_max_pred = ctx.add(new RamTensor<float>({1}), "matmul_out_max_pred");
 
-//   //MatMul
-//   ctx.push(new QntMatMulOp<uint8_t, uint8_t, int>(), {input, input_min, input_max, w, w_min, w_max},
-//           {"out_mat_pred", "matmul_out_min_pred", "matmul_out_max_pred"});
+  //MatMul
+  ctx.push(new QntMatMulOp<uint8_t, uint8_t, int>(), {input, input_min, input_max, w, w_min, w_max},
+          {"out_mat_pred", "matmul_out_min_pred", "matmul_out_max_pred"});
 
-//   //Requantization_Range
-//   S_TENSOR req_out_min = ctx.add(new RamTensor<float>({1}, "req_out_min_pred"));
-//   S_TENSOR req_out_max = ctx.add(new RamTensor<float>({1}, "req_out_max_pred"));
-//   ctx.push(new Requantization_RangeOp(), {"out_mat_pred", "matmul_out_min_pred", "matmul_out_max_pred"},
-//           {"req_out_min_pred", "req_out_max_pred"});
+  //Requantization_Range
+  ctx.add(new RamTensor<float>({1}), "req_out_min_pred");
+  ctx.add(new RamTensor<float>({1}), "req_out_max_pred");
+  ctx.push(new Requantization_RangeOp(), {"out_mat_pred", "matmul_out_min_pred", "matmul_out_max_pred"},
+          {"req_out_min_pred", "req_out_max_pred"});
 
-//   //Requantize
-//   S_TENSOR reqnt_out = ctx.add(new RamTensor<unsigned char>("reqnt_out_pred"));
-//   S_TENSOR reqnt_out_min = ctx.add(new RamTensor<float>({1}, "reqnt_out_min_pred"));
-//   S_TENSOR reqnt_out_max = ctx.add(new RamTensor<float>({1}, "reqnt_out_max_pred"));
-//   ctx.push(new RequantizeOp(), {"out_mat_pred", "matmul_out_min_pred", "matmul_out_max_pred", "req_out_min_pred", "req_out_max_pred"},
-//           {"reqnt_out_pred", "reqnt_out_min_pred", "reqnt_out_max_pred"});
+  //Requantize
+  S_TENSOR reqnt_out = ctx.add(new RamTensor<unsigned char>(), "reqnt_out_pred");
+  S_TENSOR reqnt_out_min = ctx.add(new RamTensor<float>({1}), "reqnt_out_min_pred");
+  S_TENSOR reqnt_out_max = ctx.add(new RamTensor<float>({1}), "reqnt_out_max_pred");
+  ctx.push(new RequantizeOp(), {"out_mat_pred", "matmul_out_min_pred", "matmul_out_max_pred", "req_out_min_pred", "req_out_max_pred"},
+          {"reqnt_out_pred", "reqnt_out_min_pred", "reqnt_out_max_pred"});
 
-//   //dequantize
-//   S_TENSOR deqnt_out = ctx.add(new RamTensor<float>("deqnt_out_pred"));
-//   ctx.push(new DequantizeOp(), {"reqnt_out_pred", "reqnt_out_min_pred", "reqnt_out_max_pred"}, {"deqnt_out_pred"});
+  //dequantize
+  ctx.add(new RamTensor<float>(), "deqnt_out_pred");
+  ctx.push(new DequantizeOp(), {"reqnt_out_pred", "reqnt_out_min_pred", "reqnt_out_max_pred"}, {"deqnt_out_pred"});
 
-//   //Add
-//   S_TENSOR output_z = ctx.add(new RamTensor<float>("output_z_pred")); 
-//   ctx.push(new AddOp<float, float>(), {"deqnt_out_pred", bias}, {"output_z_pred"});
+  //Add
+  ctx.add(new RamTensor<float>(), "output_z_pred"); 
+  ctx.push(new AddOp<float, float>(), {"deqnt_out_pred", bias}, {"output_z_pred"});
 
-//   //ArgMax
-//   ctx.push(new ArgMaxOp<float, int>(), {"output_z_pred", dim}, {output});
-// }
+  //ArgMax
+  ctx.push(new ArgMaxOp<float, int>(), {"output_z_pred", dim}, {output});
+}
 
-// int runMLP(string inputIdxFile) {
-//   TensorIdxImporter t_import;
-//   Context ctx;
-//   S_TENSOR x_quantized = ctx.add(new RamTensor<unsigned char>("x_quantized")); 
-//   S_TENSOR x_min = ctx.add(new RamTensor<float>({1}, "x_min"));
-//   S_TENSOR x_max = ctx.add(new RamTensor<float>({1}, "x_max")); 
-//   S_TENSOR x = ctx.add(t_import.float_import(inputIdxFile, "x"));
+int runMLP(string inputIdxFile) {
+  TensorIdxImporter t_import;
+  Context ctx;
+  ctx.add(new RamTensor<unsigned char>(), "x_quantized"); 
+  ctx.add(new RamTensor<float>({1}), "x_min");
+  ctx.add(new RamTensor<float>({1}), "x_max"); 
+  ctx.add(t_import.float_import(inputIdxFile), "x");
 
-//   tensorQuantize(ctx, "x", "x_quantized", "x_min", "x_max");
-//   ctx.eval();
+  tensorQuantize(ctx, "x", "x_quantized", "x_min", "x_max");
+  ctx.eval();
 
-//  //relu layer first
+ //relu layer first
 
-//   S_TENSOR w = ctx.add(t_import.ubyte_import(
-//       "/fs/testData/deep_mlp/import-Variable_quint8_const_0.idx", "w"));
-//   S_TENSOR w_min =
-//       ctx.add(t_import.float_import("/fs/testData/deep_mlp/import-Variable_min_0.idx", "w_min"));
-//   S_TENSOR w_max =
-//       ctx.add(t_import.float_import("/fs/testData/deep_mlp/import-Variable_max_0.idx", "w_max"));
-//   S_TENSOR b =
-//       ctx.add(t_import.float_import("/fs/testData/deep_mlp/import-Variable_1_0.idx", "b"));
-//   S_TENSOR relu_output = ctx.add(new RamTensor<unsigned char>("relu_output"));
-//   S_TENSOR relu_min = ctx.add(new RamTensor<float>({1}, "relu_min"));
-//   S_TENSOR relu_max = ctx.add(new RamTensor<float>({1}, "relu_max"));
-//   S_TENSOR z_output = ctx.add(new RamTensor<float>("z_output")); 
+  ctx.add(t_import.ubyte_import(
+      "/fs/testData/deep_mlp/import-Variable_quint8_const_0.idx"), "w");
+  ctx.add(t_import.float_import("/fs/testData/deep_mlp/import-Variable_min_0.idx"), "w_min");
+  ctx.add(t_import.float_import("/fs/testData/deep_mlp/import-Variable_max_0.idx"), "w_max");
+  ctx.add(t_import.float_import("/fs/testData/deep_mlp/import-Variable_1_0.idx"), "b");
+  ctx.add(new RamTensor<unsigned char>(), "relu_output");
+  ctx.add(new RamTensor<float>({1}), "relu_min");
+  ctx.add(new RamTensor<float>({1}), "relu_max");
+  ctx.add(new RamTensor<float>(), "z_output"); 
 
-//   ReluLayer(ctx, "x_quantized", "x_min", "x_max", "w", "w_min", "w_max", "b", "z_output");
+  ReluLayer(ctx, "x_quantized", "x_min", "x_max", "w", "w_min", "w_max", "b", "z_output");
 
-//   S_TENSOR z_qnt_output = ctx.add(new RamTensor<unsigned char>("z_qnt_output"));
-//   S_TENSOR z_min = ctx.add(new RamTensor<float>({1}, "z_min"));
-//   S_TENSOR z_max = ctx.add(new RamTensor<float>({1}, "z_max"));
-//   tensorQuantize(ctx, "z_output", "z_qnt_output", "z_min", "z_max");
+  ctx.add(new RamTensor<unsigned char>(), "z_qnt_output");
+  ctx.add(new RamTensor<float>({1}), "z_min");
+  ctx.add(new RamTensor<float>({1}), "z_max");
+  tensorQuantize(ctx, "z_output", "z_qnt_output", "z_min", "z_max");
 
-//   ctx.push(new ReluOp<unsigned char, float, unsigned char>(), {"z_qnt_output", "z_min", "z_max"}, {"relu_output", "relu_min", "relu_max"});
+  ctx.push(new ReluOp<unsigned char, float, unsigned char>(), {"z_qnt_output", "z_min", "z_max"}, {"relu_output", "relu_min", "relu_max"});
 
-//   ctx.eval();
+  ctx.eval();
 
-//   //relu layer 2
-//   S_TENSOR w2 = ctx.add(t_import.ubyte_import(
-//       "/fs/testData/deep_mlp/import-Variable_2_quint8_const_0.idx", "w2"));
-//   S_TENSOR w_min2 = ctx.add(t_import.float_import(
-//      "/fs/testData/deep_mlp/import-Variable_2_min_0.idx", "w_min2"));
-//   S_TENSOR w_max2 = ctx.add(t_import.float_import(
-//       "/fs/testData/deep_mlp/import-Variable_2_max_0.idx", "w_max2"));
-//   S_TENSOR b2 = ctx.add(t_import.float_import("/fs/testData/deep_mlp/import-Variable_3_0.idx", "b2"));
-//   S_TENSOR relu_output2 = ctx.add(new RamTensor<unsigned char>("relu_output2"));
-//   S_TENSOR relu_min2 = ctx.add(new RamTensor<float>({1}, "relu_min2"));
-//   S_TENSOR relu_max2 = ctx.add(new RamTensor<float>({1}, "relu_max2"));
+  //relu layer 2
+  ctx.add(t_import.ubyte_import(
+      "/fs/testData/deep_mlp/import-Variable_2_quint8_const_0.idx"), "w2");
+  ctx.add(t_import.float_import(
+     "/fs/testData/deep_mlp/import-Variable_2_min_0.idx"), "w_min2");
+  ctx.add(t_import.float_import(
+      "/fs/testData/deep_mlp/import-Variable_2_max_0.idx"), "w_max2");
+  ctx.add(t_import.float_import("/fs/testData/deep_mlp/import-Variable_3_0.idx"), "b2");
+  ctx.add(new RamTensor<unsigned char>(), "relu_output2");
+  ctx.add(new RamTensor<float>({1}), "relu_min2");
+  ctx.add(new RamTensor<float>({1}), "relu_max2");
 
-//   S_TENSOR z_output2 = ctx.add(new RamTensor<float>("z_output2")); 
-//   ReluLayer(ctx, "relu_output", "relu_min", "relu_max", "w2", "w_min2", "w_max2", "b2", "z_output2");
+  ctx.add(new RamTensor<float>(), "z_output2"); 
+  ReluLayer(ctx, "relu_output", "relu_min", "relu_max", "w2", "w_min2", "w_max2", "b2", "z_output2");
 
 
-//   S_TENSOR z_qnt_output2 = ctx.add(new RamTensor<unsigned char>("z_qnt_output2"));
-//   S_TENSOR z_min2 = ctx.add(new RamTensor<float>({1}, "z_min2"));
-//   S_TENSOR z_max2 = ctx.add(new RamTensor<float>({1}, "z_max2"));
-//   tensorQuantize(ctx, "z_output2", "z_qnt_output2", "z_min2", "z_max2");
+  ctx.add(new RamTensor<unsigned char>(), "z_qnt_output2");
+  ctx.add(new RamTensor<float>({1}), "z_min2");
+  ctx.add(new RamTensor<float>({1}), "z_max2");
+  tensorQuantize(ctx, "z_output2", "z_qnt_output2", "z_min2", "z_max2");
 
-//   ctx.push(new ReluOp<unsigned char, float, unsigned char>(), {"z_qnt_output2", "z_min2", "z_max2"}, {"relu_output2", "relu_min2", "relu_max2"});
+  ctx.push(new ReluOp<unsigned char, float, unsigned char>(), {"z_qnt_output2", "z_min2", "z_max2"}, {"relu_output2", "relu_min2", "relu_max2"});
 
-//   ctx.eval();
+  ctx.eval();
 
-//   S_TENSOR w3 = ctx.add(t_import.ubyte_import(
-//       "/fs/testData/deep_mlp/runPredLayer/MatMul_2_eightbit_quantized_mat_mul/"
-//       "inputs/Variable_4_quint8_const_0.idx", "w3"));
-//   S_TENSOR w2_min = ctx.add(t_import.float_import(
-//       "/fs/testData/deep_mlp/runPredLayer/MatMul_2_eightbit_quantized_mat_mul/"
-//       "inputs/Variable_4_min_0.idx", "w2_min"));
-//   S_TENSOR w2_max = ctx.add(t_import.float_import(
-//       "/fs/testData/deep_mlp/runPredLayer/MatMul_2_eightbit_quantized_mat_mul/"
-//       "inputs/Variable_4_max_0.idx", "w2_max"));
-//   S_TENSOR bias2 = ctx.add(t_import.float_import(
-//       "/fs/testData/deep_mlp/runPredLayer/add_2/inputs/Variable_5_0.idx", "bias2"));
-//   S_TENSOR dim = ctx.add(t_import.int_import(
-//       "/fs/testData/deep_mlp/runPredLayer/y_pred/inputs/"
-//       "y_pred-dimension_0.idx", "dim"));
+  ctx.add(t_import.ubyte_import(
+      "/fs/testData/deep_mlp/runPredLayer/MatMul_2_eightbit_quantized_mat_mul/"
+      "inputs/Variable_4_quint8_const_0.idx"), "w3");
+  ctx.add(t_import.float_import(
+      "/fs/testData/deep_mlp/runPredLayer/MatMul_2_eightbit_quantized_mat_mul/"
+      "inputs/Variable_4_min_0.idx"), "w2_min");
+  ctx.add(t_import.float_import(
+      "/fs/testData/deep_mlp/runPredLayer/MatMul_2_eightbit_quantized_mat_mul/"
+      "inputs/Variable_4_max_0.idx"), "w2_max");
+  ctx.add(t_import.float_import(
+      "/fs/testData/deep_mlp/runPredLayer/add_2/inputs/Variable_5_0.idx"), "bias2");
+  ctx.add(t_import.int_import(
+      "/fs/testData/deep_mlp/runPredLayer/y_pred/inputs/"
+      "y_pred-dimension_0.idx"), "dim");
 
-//   S_TENSOR pred = ctx.add(new RamTensor<int>("pred"));
-//   PredLayer(ctx, "relu_output2", "relu_min2", "relu_max2", "pred", "w3", "w2_min", "w2_max", "bias2", "dim");
-//   ctx.eval();
+  S_TENSOR pred = ctx.add(new RamTensor<int>(), "pred");
+  PredLayer(ctx, "relu_output2", "relu_min2", "relu_max2", "pred", "w3", "w2_min", "w2_max", "bias2", "dim");
+  ctx.eval();
 
 
-//   Tensor* ref_out = t_import.float_import(
-//     "/fs/testData/deep_mlp/runPredLayer/y_pred/outputs/y_pred_0.idx", "ref_out");
-//   Tensor* ref_pred = TensorCast<float, int>(ref_out, "ref_pred");
+  Tensor* ref_out = t_import.float_import(
+    "/fs/testData/deep_mlp/runPredLayer/y_pred/outputs/y_pred_0.idx");
+  Tensor* ref_pred = TensorCast<float, int>(ref_out);
 
-//   double result = Test::meanPercentErr<int>(ref_pred, pred.get());
+  double result = Test::meanPercentErr<int>(ref_pred, pred.get());
   
-//   if (result < 0.0001) {
-//     printf("PASSED %.8f\r\n\r\n", result);
-//   } else {
-//     printf("FAILED %.8f\r\n\r\n", result);
-//   }
+  if (result < 0.0001) {
+    printf("PASSED %.8f\r\n\r\n", result);
+  } else {
+    printf("FAILED %.8f\r\n\r\n", result);
+  }
 
-//   return *(pred->read<int>(0, 0));
-//   // output layer
-// }
+  return *(pred->read<int>(0, 0));
+  // output layer
+}

--- a/main.cpp
+++ b/main.cpp
@@ -7,16 +7,15 @@
 #include "tensorIdxImporterTests.hpp"
 #include "context.hpp"
 #include "ArrayTests.hpp"
-#include "MathTests.hpp"
-#include "MatrixTests.hpp"
-#include "context_test.hpp"
+// #include "MathTests.hpp"
+// #include "MatrixTests.hpp"
 #include "tensor_test.hpp"
-#include "NnTests.hpp"
-#include "mlp_test.hpp"
-#include "deep_mnist_mlp.hpp"
+// #include "NnTests.hpp"
+// #include "mlp_test.hpp"
+// #include "deep_mnist_mlp.hpp"
 #include "context_test.hpp"
 #include "MathTests.hpp"
-#include "MatrixTests.hpp"
+// #include "MatrixTests.hpp"
 
 Serial pc(USBTX, USBRX, 115200);
 SDBlockDevice bd(MBED_CONF_APP_SD_MOSI, MBED_CONF_APP_SD_MISO,
@@ -27,11 +26,11 @@ int main(int argc, char** argv) {
   ON_ERR(bd.init(), "SDBlockDevice init ");
   ON_ERR(fs.mount(&bd), "Mounting the filesystem on \"/fs\". ");
 
-  printf("Deep MLP on Mbed (Trained with Tensorflow)\r\n\r\n");
-  printf("running deep-mlp...\r\n");
+  // printf("Deep MLP on Mbed (Trained with Tensorflow)\r\n\r\n");
+  // printf("running deep-mlp...\r\n");
 
-  int prediction = runMLP("/fs/testData/deep_mlp/import-Placeholder_0.idx");
-  printf("prediction: %d\r\n\r\n\r\n\r\n", prediction);
+  // int prediction = runMLP("/fs/testData/deep_mlp/import-Placeholder_0.idx");
+  // printf("prediction: %d\r\n\r\n\r\n\r\n", prediction);
 
   printf("IDX import:\r\n");
   idxImporterTest idxTest;
@@ -69,17 +68,17 @@ int main(int argc, char** argv) {
   printf("Math result...\r\n");
   mathTests.printSummary();
 
-  printf("running matrix test:\r\n");
-  matrixOpsTest matrixTests;
-  matrixTests.runAll();
-  printf("running matrix result ...\r\n");
-  matrixTests.printSummary();
+  // printf("running matrix test:\r\n");
+  // matrixOpsTest matrixTests;
+  // matrixTests.runAll();
+  // printf("running matrix result ...\r\n");
+  // matrixTests.printSummary();
 
-  printf("NnOpS: \r\n");
-  NnOpsTest nnTest;
-  nnTest.runAll();
-  printf("Nn Ops result...\r\n");
-  nnTest.printSummary();
+  // printf("NnOpS: \r\n");
+  // NnOpsTest nnTest;
+  // nnTest.runAll();
+  // printf("Nn Ops result...\r\n");
+  // nnTest.printSummary();
 
 /*   printf("mlp test: \r\n");
   mlpTest mlpt;

--- a/main.cpp
+++ b/main.cpp
@@ -7,15 +7,13 @@
 #include "tensorIdxImporterTests.hpp"
 #include "context.hpp"
 #include "ArrayTests.hpp"
-// #include "MathTests.hpp"
-// #include "MatrixTests.hpp"
+#include "MatrixTests.hpp"
 #include "tensor_test.hpp"
-// #include "NnTests.hpp"
+#include "NnTests.hpp"
 // #include "mlp_test.hpp"
-// #include "deep_mnist_mlp.hpp"
+#include "deep_mnist_mlp.hpp"
 #include "context_test.hpp"
 #include "MathTests.hpp"
-// #include "MatrixTests.hpp"
 
 Serial pc(USBTX, USBRX, 115200);
 SDBlockDevice bd(MBED_CONF_APP_SD_MOSI, MBED_CONF_APP_SD_MISO,
@@ -26,11 +24,11 @@ int main(int argc, char** argv) {
   ON_ERR(bd.init(), "SDBlockDevice init ");
   ON_ERR(fs.mount(&bd), "Mounting the filesystem on \"/fs\". ");
 
-  // printf("Deep MLP on Mbed (Trained with Tensorflow)\r\n\r\n");
-  // printf("running deep-mlp...\r\n");
+  printf("Deep MLP on Mbed (Trained with Tensorflow)\r\n\r\n");
+  printf("running deep-mlp...\r\n");
 
-  // int prediction = runMLP("/fs/testData/deep_mlp/import-Placeholder_0.idx");
-  // printf("prediction: %d\r\n\r\n\r\n\r\n", prediction);
+  int prediction = runMLP("/fs/testData/deep_mlp/import-Placeholder_0.idx");
+  printf("prediction: %d\r\n\r\n\r\n\r\n", prediction);
 
   printf("IDX import:\r\n");
   idxImporterTest idxTest;
@@ -68,17 +66,17 @@ int main(int argc, char** argv) {
   printf("Math result...\r\n");
   mathTests.printSummary();
 
-  // printf("running matrix test:\r\n");
-  // matrixOpsTest matrixTests;
-  // matrixTests.runAll();
-  // printf("running matrix result ...\r\n");
-  // matrixTests.printSummary();
+  printf("running matrix test:\r\n");
+  matrixOpsTest matrixTests;
+  matrixTests.runAll();
+  printf("running matrix result ...\r\n");
+  matrixTests.printSummary();
 
-  // printf("NnOpS: \r\n");
-  // NnOpsTest nnTest;
-  // nnTest.runAll();
-  // printf("Nn Ops result...\r\n");
-  // nnTest.printSummary();
+  printf("NnOpS: \r\n");
+  NnOpsTest nnTest;
+  nnTest.runAll();
+  printf("Nn Ops result...\r\n");
+  nnTest.printSummary();
 
 /*   printf("mlp test: \r\n");
   mlpTest mlpt;

--- a/tensorIdxImporter.hpp
+++ b/tensorIdxImporter.hpp
@@ -33,25 +33,25 @@ class TensorIdxImporter {
   HeaderMeta header;
   HeaderMeta parseHeader(void);
   template <typename U>
-  Tensor* loader(string& filename, IDX_DTYPE idx_type, string name);
+  Tensor* loader(string& filename, IDX_DTYPE idx_type);
   void open(string filename);
   // void open(FILE *fp);
 
  public:
-  Tensor* ubyte_import(string filename, string name) {
-    return loader<unsigned char>(filename, IDX_DTYPE::idx_ubyte, name);
+  Tensor* ubyte_import(string filename) {
+    return loader<unsigned char>(filename, IDX_DTYPE::idx_ubyte);
   }
-  Tensor* byte_import(string filename, string name) {
-    return loader<char>(filename, IDX_DTYPE::idx_byte, name);
+  Tensor* byte_import(string filename) {
+    return loader<char>(filename, IDX_DTYPE::idx_byte);
   }
-  Tensor* short_import(string filename, string name) {
-    return loader<short>(filename, IDX_DTYPE::idx_short, name);
+  Tensor* short_import(string filename) {
+    return loader<short>(filename, IDX_DTYPE::idx_short);
   }
-  Tensor* int_import(string filename, string name) {
-    return loader<int>(filename, IDX_DTYPE::idx_int, name);
+  Tensor* int_import(string filename) {
+    return loader<int>(filename, IDX_DTYPE::idx_int);
   }
-  Tensor* float_import(string filename, string name) {
-    return loader<float>(filename, IDX_DTYPE::idx_float, name);
+  Tensor* float_import(string filename) {
+    return loader<float>(filename, IDX_DTYPE::idx_float);
   }
   uint32_t getMagicNumber(unsigned char dtype, unsigned char dim);
   uint8_t getIdxDTypeSize(IDX_DTYPE dtype);
@@ -65,7 +65,7 @@ class TensorIdxImporter {
 
 
 template <typename U>
-Tensor* TensorIdxImporter::loader(string& filename, IDX_DTYPE idx_type, string name) {
+Tensor* TensorIdxImporter::loader(string& filename, IDX_DTYPE idx_type) {
   fp = fopen(filename.c_str(), "r");
 
   DEBUG("Opening file %s ", filename.c_str());
@@ -79,7 +79,7 @@ Tensor* TensorIdxImporter::loader(string& filename, IDX_DTYPE idx_type, string n
 
   fseek(fp, header.dataPos, SEEK_SET);  // need error  handling
 
-  Tensor* t = new RamTensor<U>(header.dim, name);  // tensor allocated
+  Tensor* t = new RamTensor<U>(header.dim);  // tensor allocated
   const uint8_t unit_size = t->unit_size();
 
   U* val = (U*)malloc(unit_size);

--- a/tensorIdxImporterTests.hpp
+++ b/tensorIdxImporterTests.hpp
@@ -20,7 +20,7 @@ class idxImporterTest : public Test {
     TensorIdxImporter t_import;
     timer_start();
     Tensor* t =
-        t_import.ubyte_import("/fs/testData/idxImport/uint8_4d_power2.idx", "uchar1");
+        t_import.ubyte_import("/fs/testData/idxImport/uint8_4d_power2.idx");
     timer_stop();
     double result = sum<unsigned char>(t);
     passed(result == 4518);
@@ -32,7 +32,7 @@ class idxImporterTest : public Test {
     TensorIdxImporter t_import;
     timer_start();
     Tensor* t =
-        t_import.short_import("/fs/testData/idxImport/int16_4d_power2.idx", "short1");
+        t_import.short_import("/fs/testData/idxImport/int16_4d_power2.idx");
     timer_stop();
     double result = sum<short>(t);
     passed(result == 270250);
@@ -44,10 +44,10 @@ class idxImporterTest : public Test {
     TensorIdxImporter t_import;
     timer_start();
     Tensor* t =
-        t_import.int_import("/fs/testData/idxImport/int32_4d_power2.idx", "int1");
+        t_import.int_import("/fs/testData/idxImport/int32_4d_power2.idx");
     timer_stop();
     double result = sum<int>(t);
-    passed(result == 5748992600);
+    passed(result == 7158278745);
     delete t;
   }
 
@@ -56,7 +56,7 @@ class idxImporterTest : public Test {
     TensorIdxImporter t_import;
     timer_start();
     Tensor* t =
-        t_import.float_import("/fs/testData/idxImport/float_4d_power2.idx", "float1");
+        t_import.float_import("/fs/testData/idxImport/float_4d_power2.idx");
     timer_stop();
 
     double result = sum<float>(t);

--- a/tensor_test.hpp
+++ b/tensor_test.hpp
@@ -12,7 +12,7 @@ class tensorTest : public Test {
   public:
       void runResize() {
       testStart("tensortest");
-          Tensor* a = new RamTensor<int>({3, 2, 3}, "a");
+          Tensor* a = new RamTensor<int>({3, 2, 3});
           std::vector<uint32_t> v({1, 5, 8});
           a->resize<int>(v);
           bool res = testsize(1 * 5 * 8, a->getSize());
@@ -36,7 +36,7 @@ class transTest : public Test {
       std::default_random_engine gen;
       vector<uint32_t> tmp({2, 3, 4, 5});
       std::string a_s = "input" + std::to_string(i);
-      S_TENSOR inputTensor = ctx.add(defer(new RamTensor<int>(tmp, a_s)));
+      S_TENSOR inputTensor = ctx.add(new RamTensor<int>(tmp), a_s);
       vector<uint8_t> permute = {2, 3, 1, 0};
       vector<uint32_t> g = inputTensor->getShape();
       std::shuffle(permute.begin(), permute.end(), gen);
@@ -44,7 +44,7 @@ class transTest : public Test {
       permuteIndexTransform trans(inputTensor->getShape(), permute);
 
       std::string a_o = "output" + std::to_string(i);
-      S_TENSOR output = ctx.add(defer(new RamTensor<int>(trans.getNewShape(), a_o)));
+      S_TENSOR output = ctx.add(new RamTensor<int>(trans.getNewShape()), a_o);
       vector<uint32_t> s = output->getShape();
       res = testshape<uint32_t>(g, s, permute);
       if (!res) {
@@ -61,7 +61,7 @@ class transTest : public Test {
     vector<int> output_1({2, 2, 3, 5, 6, 6, 4, 5, 7, 5, 1, 9,
                           1, 3, 2, 2, 5, 3, 3, 6, 3, 4, 9, 2});
 
-    S_TENSOR inputTensor2 = ctx.add(defer(new RamTensor<int>({2, 3, 4}, "inputTensor2")));
+    S_TENSOR inputTensor2 = ctx.add(new RamTensor<int>({2, 3, 4}), "inputTensor2");
     vector<uint8_t> permute = {0, 2, 1};
 
     permuteIndexTransform trans(inputTensor2->getShape(), permute);
@@ -87,7 +87,7 @@ class transTest : public Test {
     vector<int> output_2({2, 1, 2, 3, 3, 2, 5, 2, 6, 5, 6, 3,
                           4, 3, 5, 6, 7, 3, 5, 4, 1, 9, 9, 2});
 
-    S_TENSOR inputTensor3 = ctx.add(defer(new RamTensor<int>({2, 4, 3}, "inputTensor3")));
+    S_TENSOR inputTensor3 = ctx.add(new RamTensor<int>({2, 4, 3}), "inputTensor3");
     vector<uint8_t> permute2 = {1, 2, 0};
     permuteIndexTransform trans2(inputTensor3->getShape(), permute2);
     testStart("test vec 2 for transform");
@@ -107,7 +107,7 @@ class transTest : public Test {
     vector<int> output_3({8, 2, 8, 1, 0, 3, 4, 6, 2, 6, 0, 6, 3, 9,
                           2, 7, 0, 7, 0, 4, 8, 9, 0, 4, 3, 6, 8});
 
-    S_TENSOR inputTensor4 = ctx.add(defer(new RamTensor<int>({1, 3, 3, 3}, "inputTensor4")));
+    S_TENSOR inputTensor4 = ctx.add(new RamTensor<int>({1, 3, 3, 3}), "inputTensor4");
     vector<uint8_t> permute3 = {0, 3, 2, 1};
     permuteIndexTransform trans3(inputTensor4->getShape(), permute3);
     testStart("test vec 4d for transform");

--- a/tensor_test.hpp
+++ b/tensor_test.hpp
@@ -36,7 +36,7 @@ class transTest : public Test {
       std::default_random_engine gen;
       vector<uint32_t> tmp({2, 3, 4, 5});
       std::string a_s = "input" + std::to_string(i);
-      S_TENSOR inputTensor = ctx.add(new RamTensor<int>(tmp, a_s));
+      S_TENSOR inputTensor = ctx.add(defer(new RamTensor<int>(tmp, a_s)));
       vector<uint8_t> permute = {2, 3, 1, 0};
       vector<uint32_t> g = inputTensor->getShape();
       std::shuffle(permute.begin(), permute.end(), gen);
@@ -44,7 +44,7 @@ class transTest : public Test {
       permuteIndexTransform trans(inputTensor->getShape(), permute);
 
       std::string a_o = "output" + std::to_string(i);
-      S_TENSOR output = ctx.add(new RamTensor<int>(trans.getNewShape(), a_o));
+      S_TENSOR output = ctx.add(defer(new RamTensor<int>(trans.getNewShape(), a_o)));
       vector<uint32_t> s = output->getShape();
       res = testshape<uint32_t>(g, s, permute);
       if (!res) {
@@ -61,7 +61,7 @@ class transTest : public Test {
     vector<int> output_1({2, 2, 3, 5, 6, 6, 4, 5, 7, 5, 1, 9,
                           1, 3, 2, 2, 5, 3, 3, 6, 3, 4, 9, 2});
 
-    S_TENSOR inputTensor2 = ctx.add(new RamTensor<int>({2, 3, 4}, "inputTensor2"));
+    S_TENSOR inputTensor2 = ctx.add(defer(new RamTensor<int>({2, 3, 4}, "inputTensor2")));
     vector<uint8_t> permute = {0, 2, 1};
 
     permuteIndexTransform trans(inputTensor2->getShape(), permute);
@@ -87,7 +87,7 @@ class transTest : public Test {
     vector<int> output_2({2, 1, 2, 3, 3, 2, 5, 2, 6, 5, 6, 3,
                           4, 3, 5, 6, 7, 3, 5, 4, 1, 9, 9, 2});
 
-    S_TENSOR inputTensor3 = ctx.add(new RamTensor<int>({2, 4, 3}, "inputTensor3"));
+    S_TENSOR inputTensor3 = ctx.add(defer(new RamTensor<int>({2, 4, 3}, "inputTensor3")));
     vector<uint8_t> permute2 = {1, 2, 0};
     permuteIndexTransform trans2(inputTensor3->getShape(), permute2);
     testStart("test vec 2 for transform");
@@ -107,7 +107,7 @@ class transTest : public Test {
     vector<int> output_3({8, 2, 8, 1, 0, 3, 4, 6, 2, 6, 0, 6, 3, 9,
                           2, 7, 0, 7, 0, 4, 8, 9, 0, 4, 3, 6, 8});
 
-    S_TENSOR inputTensor4 = ctx.add(new RamTensor<int>({1, 3, 3, 3}, "inputTensor4"));
+    S_TENSOR inputTensor4 = ctx.add(defer(new RamTensor<int>({1, 3, 3, 3}, "inputTensor4")));
     vector<uint8_t> permute3 = {0, 3, 2, 1};
     permuteIndexTransform trans3(inputTensor4->getShape(), permute3);
     testStart("test vec 4d for transform");

--- a/uTensorBase.cpp
+++ b/uTensorBase.cpp
@@ -12,3 +12,8 @@ void Operator::setOutputs(S_TList &_outputs) {
   outputs = _outputs;
 
 }
+
+void Operator::empty(void) {
+  inputs.empty();
+  outputs.empty();
+}

--- a/uTensorBase.hpp
+++ b/uTensorBase.hpp
@@ -24,6 +24,7 @@ public:
   S_TList getOutputs(void) { return outputs;}
   uint8_t getNumInputs(void) { return n_inputs; }
   uint8_t getNumOutputs(void) { return n_outputs; }
+  void empty(void);
 
   Operator() {
     n_inputs = 0;  //overridden by constructor


### PR DESCRIPTION
modified Context interface to enable cacheable tensors, static tensors and operators.
caching policy yet to be implemented in context::gc()